### PR TITLE
fix(web): close P0 frontend boundaries

### DIFF
--- a/apps/web/src/app/core/auth/auth.service.ts
+++ b/apps/web/src/app/core/auth/auth.service.ts
@@ -51,13 +51,15 @@ export class AuthService {
   // ─── Reactive state ────────────────────────────────────────────────────────
 
   /** Current Supabase session. null = unauthenticated or not yet loaded. */
-  readonly session = signal<Session | null>(null);
+  private readonly _session = signal<Session | null>(null);
+  readonly session = this._session.asReadonly();
 
   /** Shortcut: the authenticated user from the current session. */
-  readonly user = computed<User | null>(() => this.session()?.user ?? null);
+  readonly user = computed<User | null>(() => this._session()?.user ?? null);
 
   /** True while initialize() is still resolving. Guards use this to wait. */
-  readonly loading = signal<boolean>(true);
+  private readonly _loading = signal<boolean>(true);
+  readonly loading = this._loading.asReadonly();
 
   // ─── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -69,12 +71,12 @@ export class AuthService {
   async initialize(): Promise<void> {
     // Load any existing session from storage
     const { data } = await this.supabase.client.auth.getSession();
-    this.session.set(data.session);
+    this._session.set(data.session);
 
     // Subscribe to auth state changes for the lifetime of the app.
     // This fires on: sign-in, sign-out, token refresh, password recovery.
     this.supabase.client.auth.onAuthStateChange((event, session) => {
-      this.session.set(session);
+      this._session.set(session);
 
       // After a PASSWORD_RECOVERY link is clicked, Supabase fires SIGNED_IN
       // with type 'recovery'. Route the user to the update-password form.
@@ -83,7 +85,7 @@ export class AuthService {
       }
     });
 
-    this.loading.set(false);
+    this._loading.set(false);
   }
 
   // ─── Auth actions ───────────────────────────────────────────────────────────

--- a/apps/web/src/app/core/filename-parser/filename-parser.service.spec.ts
+++ b/apps/web/src/app/core/filename-parser/filename-parser.service.spec.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from 'vitest';
-import { FilenameParserService } from './filename-parser/filename-parser.service';
-import { LocationPathParserService } from './location-path-parser/location-path-parser.service';
-import { UploadLocationConfigService } from './upload/upload-location-config.service';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LocationPathParserService } from '../location-path-parser/location-path-parser.service';
+import { UploadLocationConfigService } from '../upload/upload-location-config.service';
+import { FilenameParserService } from './filename-parser.service';
+
+function provideService(config = new UploadLocationConfigService()): FilenameParserService {
+  TestBed.configureTestingModule({
+    providers: [
+      FilenameParserService,
+      LocationPathParserService,
+      { provide: UploadLocationConfigService, useValue: config },
+    ],
+  });
+  return TestBed.inject(FilenameParserService);
+}
 
 describe('FilenameParserService', () => {
-  const service = new FilenameParserService();
+  let service: FilenameParserService;
+
+  beforeEach(() => {
+    service = provideService();
+  });
 
   it('extracts address from Wienzeile-style filename with high confidence (street suffix)', () => {
     const parsed = service.extractAddress('Linke Wienzeile 26, Wien_0327.jpg');
@@ -34,7 +50,8 @@ describe('FilenameParserService', () => {
   it('uses configurable single-word minimum length threshold', () => {
     const config = new UploadLocationConfigService();
     config.patchConfig({ filenameSingleWordMinLength: 10, filenameSingleWordCityMinLength: 4 });
-    const configurableService = new FilenameParserService(new LocationPathParserService(), config);
+    TestBed.resetTestingModule();
+    const configurableService = provideService(config);
 
     const parsed = configurableService.extractAddress('Fahrafeld 4.jpg');
     expect(parsed).toBeUndefined();

--- a/apps/web/src/app/core/filename-parser/filename-parser.service.ts
+++ b/apps/web/src/app/core/filename-parser/filename-parser.service.ts
@@ -12,7 +12,7 @@
  *   `low` for conservative fallback pattern matches.
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { LocationPathParserService } from '../location-path-parser/location-path-parser.service';
 import { UploadLocationConfigService } from '../upload/upload-location-config.service';
 
@@ -55,10 +55,8 @@ export interface ParsedAddress {
 
 @Injectable({ providedIn: 'root' })
 export class FilenameParserService {
-  constructor(
-    private readonly locationPathParser: LocationPathParserService = new LocationPathParserService(),
-    private readonly locationConfig: UploadLocationConfigService = new UploadLocationConfigService(),
-  ) {}
+  private readonly locationPathParser = inject(LocationPathParserService);
+  private readonly locationConfig = inject(UploadLocationConfigService);
 
   /**
    * Attempts to extract an address hint from a filename with confidence level.

--- a/apps/web/src/app/core/filter/filter.service.ts
+++ b/apps/web/src/app/core/filter/filter.service.ts
@@ -9,12 +9,13 @@ let nextRuleId = 0;
 @Injectable({ providedIn: 'root' })
 export class FilterService {
   private readonly metadata = inject(MetadataService);
-  readonly rules = signal<FilterRule[]>([]);
+  private readonly _rules = signal<FilterRule[]>([]);
+  readonly rules = this._rules.asReadonly();
 
-  readonly activeCount = computed(() => this.rules().length);
+  readonly activeCount = computed(() => this._rules().length);
 
   addRule(): void {
-    this.rules.update((list) => [
+    this._rules.update((list) => [
       ...list,
       {
         id: `rule-${++nextRuleId}`,
@@ -27,15 +28,15 @@ export class FilterService {
   }
 
   updateRule(id: string, patch: Partial<FilterRule>): void {
-    this.rules.update((list) => list.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+    this._rules.update((list) => list.map((r) => (r.id === id ? { ...r, ...patch } : r)));
   }
 
   removeRule(id: string): void {
-    this.rules.update((list) => list.filter((r) => r.id !== id));
+    this._rules.update((list) => list.filter((r) => r.id !== id));
   }
 
   clearAll(): void {
-    this.rules.set([]);
+    this._rules.set([]);
   }
 
   /**

--- a/apps/web/src/app/core/location-path-parser/location-path-parser.service.spec.ts
+++ b/apps/web/src/app/core/location-path-parser/location-path-parser.service.spec.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it } from 'vitest';
-import { LocationPathParserService } from './location-path-parser/location-path-parser.service';
-import { UploadLocationConfigService } from './upload/upload-location-config.service';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { UploadLocationConfigService } from '../upload/upload-location-config.service';
+import { LocationPathParserService } from './location-path-parser.service';
+
+function provideService(config = new UploadLocationConfigService()): LocationPathParserService {
+  TestBed.configureTestingModule({
+    providers: [
+      LocationPathParserService,
+      { provide: UploadLocationConfigService, useValue: config },
+    ],
+  });
+  return TestBed.inject(LocationPathParserService);
+}
 
 describe('LocationPathParserService', () => {
-  const service = new LocationPathParserService();
+  let service: LocationPathParserService;
+
+  beforeEach(() => {
+    service = provideService();
+  });
 
   it('parses hierarchical folder path into city/zip/street/house components', () => {
     const result = service.parsePathSegments('/Austria/1070_Wien/Denisgasse 12/photo.jpg');
@@ -52,7 +67,8 @@ describe('LocationPathParserService', () => {
   it('uses configurable disambiguation auto-assign threshold', () => {
     const config = new UploadLocationConfigService();
     config.patchConfig({ disambiguationAutoAssignThreshold: 0.999 });
-    const configurableService = new LocationPathParserService(config);
+    TestBed.resetTestingModule();
+    const configurableService = provideService(config);
 
     const result = configurableService.parsePathSegments('/Austria/1070/Denisgasse 12/photo.jpg');
     expect(result.disambiguation.algorithm).toBe('cluster-majority');

--- a/apps/web/src/app/core/location-path-parser/location-path-parser.service.ts
+++ b/apps/web/src/app/core/location-path-parser/location-path-parser.service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { UploadLocationConfigService } from '../upload/upload-location-config.service';
 import { CITY_REGISTRY } from './city-registry.const';
 import { POSTAL_CODE_PATTERNS } from './postal-code-patterns.const';
@@ -77,13 +77,9 @@ function uniq(values: readonly string[]): string[] {
 
 @Injectable({ providedIn: 'root' })
 export class LocationPathParserService {
-  private readonly disambiguationAlgorithm: DisambiguationAlgorithm;
-
-  constructor(
-    private readonly locationConfig: UploadLocationConfigService = new UploadLocationConfigService(),
-  ) {
-    this.disambiguationAlgorithm = this.locationConfig.getConfig().disambiguationAlgorithm;
-  }
+  private readonly locationConfig = inject(UploadLocationConfigService);
+  private readonly disambiguationAlgorithm: DisambiguationAlgorithm =
+    this.locationConfig.getConfig().disambiguationAlgorithm;
 
   parsePathSegments(fullPath: string): AddressExtractionResult {
     const context = emptyContext();

--- a/apps/web/src/app/core/media-query/media-query.service.ts
+++ b/apps/web/src/app/core/media-query/media-query.service.ts
@@ -24,6 +24,11 @@ interface MediaItemRow {
     | null;
 }
 
+interface MediaItemLookupRow {
+  id: string;
+  source_image_id: string | null;
+}
+
 export interface MediaLoadResult {
   items: ImageRecord[];
   totalCount: number | null;
@@ -34,6 +39,11 @@ export interface MediaLoadOptions {
   offset?: number;
   limit?: number;
   includeCount?: boolean;
+}
+
+export interface MediaMutationResult {
+  ok: boolean;
+  errorMessage: string | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -80,6 +90,49 @@ export class MediaQueryService {
     return { items, totalCount, projectNameById: new Map<string, string>() };
   }
 
+  async resolveMediaItemIdsByLookupIds(lookupIds: readonly string[]): Promise<string[]> {
+    const uniqueLookupIds = this.normalizeIds(lookupIds);
+    if (uniqueLookupIds.length === 0) {
+      return [];
+    }
+
+    const idList = uniqueLookupIds.join(',');
+    const { data, error } = await this.supabase.client
+      .from('media_items')
+      .select('id,source_image_id')
+      .or(`id.in.(${idList}),source_image_id.in.(${idList})`);
+
+    if (error || !Array.isArray(data)) {
+      return [];
+    }
+
+    return Array.from(
+      new Set(
+        (data as MediaItemLookupRow[])
+          .map((row) => (typeof row.id === 'string' ? row.id : null))
+          .filter((id): id is string => !!id),
+      ),
+    );
+  }
+
+  async deleteMediaItems(mediaItemIds: readonly string[]): Promise<MediaMutationResult> {
+    const uniqueMediaItemIds = this.normalizeIds(mediaItemIds);
+    if (uniqueMediaItemIds.length === 0) {
+      return { ok: true, errorMessage: null };
+    }
+
+    const { error } = await this.supabase.client
+      .from('media_items')
+      .delete()
+      .in('id', uniqueMediaItemIds);
+
+    if (error) {
+      return { ok: false, errorMessage: error.message };
+    }
+
+    return { ok: true, errorMessage: null };
+  }
+
   private toImageRecord(row: MediaItemRow): ImageRecord {
     const unresolved = row.location_status === 'pending' || row.location_status === 'no_gps';
 
@@ -105,5 +158,9 @@ export class MediaQueryService {
       direction: null,
       location_unresolved: unresolved,
     };
+  }
+
+  private normalizeIds(ids: readonly string[]): string[] {
+    return Array.from(new Set(ids.filter((id) => typeof id === 'string' && id.length > 0)));
   }
 }

--- a/apps/web/src/app/core/metadata/metadata.service.ts
+++ b/apps/web/src/app/core/metadata/metadata.service.ts
@@ -27,14 +27,15 @@ export class MetadataService {
   private readonly i18nService = inject(I18nService);
   private readonly adapter = inject(SupabaseMetadataAdapter);
 
-  readonly customMetadataFields = signal<MetadataFieldDefinition[]>([]);
+  private readonly _customMetadataFields = signal<MetadataFieldDefinition[]>([]);
+  readonly customMetadataFields = this._customMetadataFields.asReadonly();
 
   readonly allMetadataFields = computed<MetadataFieldDefinition[]>(() => [
     ...BUILT_IN_METADATA_FIELDS.map((field) => ({
       ...field,
       label: this.i18nService.translateOriginal(field.label, field.label),
     })),
-    ...this.customMetadataFields(),
+    ...this._customMetadataFields(),
   ]);
 
   readonly sortableMetadataFields = computed(() =>
@@ -92,13 +93,13 @@ export class MetadataService {
   }
 
   setMetadataFieldsFromKeys(keys: MetadataKeyRecord[]): void {
-    this.customMetadataFields.set(mapMetadataKeysToFieldDefinitions(keys, METADATA_TYPE_ICONS));
+    this._customMetadataFields.set(mapMetadataKeysToFieldDefinitions(keys, METADATA_TYPE_ICONS));
   }
 
   async refreshMetadataFields(): Promise<void> {
     const keys = await this.adapter.fetchMetadataKeys();
     if (keys.length === 0) {
-      this.customMetadataFields.set([]);
+      this._customMetadataFields.set([]);
       return;
     }
     this.setMetadataFieldsFromKeys(keys);

--- a/apps/web/src/app/core/projects/projects.service.ts
+++ b/apps/web/src/app/core/projects/projects.service.ts
@@ -3,7 +3,9 @@ import { SupabaseService } from '../supabase/supabase.service';
 import type {
   ProjectColorKey,
   ProjectListItem,
+  ProjectMutationResult,
   ProjectSearchCounts,
+  ProjectSelectOption,
   ProjectStatusFilter,
   ProjectScopedWorkspaceImage,
 } from './projects.types';
@@ -134,6 +136,25 @@ export class ProjectsService {
     } finally {
       this.projectsLoadPromise = null;
     }
+  }
+
+  async loadProjectSelectOptions(): Promise<ProjectSelectOption[]> {
+    const { data, error } = await this.supabase.client
+      .from('projects')
+      .select('id,name')
+      .order('name', { ascending: true });
+
+    if (error || !Array.isArray(data)) {
+      return [];
+    }
+
+    return (data as Array<{ id: string; name: string | null }>)
+      .filter((row): row is { id: string; name: string } => {
+        return (
+          typeof row.id === 'string' && typeof row.name === 'string' && row.name.length > 0
+        );
+      })
+      .map((row) => ({ id: row.id, name: row.name }));
   }
 
   private async loadProjectsFresh(): Promise<ProjectListItem[]> {
@@ -417,6 +438,32 @@ export class ProjectsService {
     return ok;
   }
 
+  async assignMediaItemsToProject(
+    mediaItemIds: readonly string[],
+    projectId: string,
+  ): Promise<ProjectMutationResult> {
+    const uniqueMediaItemIds = this.normalizeIds(mediaItemIds);
+    if (uniqueMediaItemIds.length === 0) {
+      return { ok: true, errorMessage: null };
+    }
+
+    const rows = uniqueMediaItemIds.map((mediaItemId) => ({
+      media_item_id: mediaItemId,
+      project_id: projectId,
+    }));
+    const { error } = await this.supabase.client
+      .from('media_projects')
+      .upsert(rows, { onConflict: 'media_item_id,project_id', ignoreDuplicates: true });
+
+    if (error) {
+      return { ok: false, errorMessage: error.message };
+    }
+
+    this.invalidateProjectsReadCaches();
+    this.projectWorkspaceImagesCache.clear();
+    return { ok: true, errorMessage: null };
+  }
+
   async removeMediaFromProject(mediaItemId: string, projectId: string): Promise<boolean> {
     const { error } = await this.supabase.client
       .from('media_projects')
@@ -433,6 +480,28 @@ export class ProjectsService {
     return ok;
   }
 
+  async removeMediaItemsFromProjects(
+    mediaItemIds: readonly string[],
+  ): Promise<ProjectMutationResult> {
+    const uniqueMediaItemIds = this.normalizeIds(mediaItemIds);
+    if (uniqueMediaItemIds.length === 0) {
+      return { ok: true, errorMessage: null };
+    }
+
+    const { error } = await this.supabase.client
+      .from('media_projects')
+      .delete()
+      .in('media_item_id', uniqueMediaItemIds);
+
+    if (error) {
+      return { ok: false, errorMessage: error.message };
+    }
+
+    this.invalidateProjectsReadCaches();
+    this.projectWorkspaceImagesCache.clear();
+    return { ok: true, errorMessage: null };
+  }
+
   // No "primary project" concept — memberships only via media_projects.
 
   private invalidateProjectsReadCaches(): void {
@@ -442,6 +511,10 @@ export class ProjectsService {
 
   private invalidateProjectWorkspaceCache(projectId: string): void {
     this.projectWorkspaceImagesCache.delete(projectId);
+  }
+
+  private normalizeIds(ids: readonly string[]): string[] {
+    return Array.from(new Set(ids.filter((id) => typeof id === 'string' && id.length > 0)));
   }
 
   private async fetchProjects(): Promise<ProjectRow[]> {

--- a/apps/web/src/app/core/projects/projects.types.ts
+++ b/apps/web/src/app/core/projects/projects.types.ts
@@ -26,6 +26,16 @@ export interface ProjectListItem extends ProjectRecord {
   country: string | null;
 }
 
+export interface ProjectSelectOption {
+  id: string;
+  name: string;
+}
+
+export interface ProjectMutationResult {
+  ok: boolean;
+  errorMessage: string | null;
+}
+
 export interface ProjectsSnapshot {
   projects: ProjectListItem[];
 }

--- a/apps/web/src/app/core/toast/toast.service.ts
+++ b/apps/web/src/app/core/toast/toast.service.ts
@@ -15,7 +15,8 @@ function generateId(): string {
 
 @Injectable({ providedIn: 'root' })
 export class ToastService {
-  readonly items = signal<ToastItem[]>([]);
+  private readonly _items = signal<ToastItem[]>([]);
+  readonly items = this._items.asReadonly();
 
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -24,7 +25,7 @@ export class ToastService {
     const duration = options.duration ?? (type === 'error' ? ERROR_DURATION : DEFAULT_DURATION);
 
     if (options.dedupe) {
-      const existing = this.items().find(
+      const existing = this._items().find(
         (t) => t.message === options.message && t.type === type && t.state !== 'exiting',
       );
       if (existing) return existing.id;
@@ -40,7 +41,7 @@ export class ToastService {
       startedAt: Date.now(),
     };
 
-    this.items.update((list) => [...list, item]);
+    this._items.update((list) => [...list, item]);
     this.enforceMaxLimit();
 
     if (duration > 0) {
@@ -51,26 +52,26 @@ export class ToastService {
   }
 
   dismiss(id: string): void {
-    const item = this.items().find((t) => t.id === id);
+    const item = this._items().find((t) => t.id === id);
     if (!item || item.state === 'exiting') return;
     this.clearTimer(id);
-    this.items.update((list) =>
+    this._items.update((list) =>
       list.map((t) => (t.id === id ? { ...t, state: 'exiting' as const } : t)),
     );
   }
 
   dismissAll(): void {
-    for (const item of this.items()) {
+    for (const item of this._items()) {
       this.clearTimer(item.id);
     }
-    this.items.update((list) =>
+    this._items.update((list) =>
       list.filter((t) => t.state !== 'exiting').map((t) => ({ ...t, state: 'exiting' as const })),
     );
   }
 
   /** Called by ToastItemComponent after its enter animation completes. */
   markVisible(id: string): void {
-    this.items.update((list) =>
+    this._items.update((list) =>
       list.map((t) =>
         t.id === id && t.state === 'entering' ? { ...t, state: 'visible' as const } : t,
       ),
@@ -79,24 +80,24 @@ export class ToastService {
 
   /** Called by ToastItemComponent after its exit animation completes. */
   afterExit(id: string): void {
-    this.items.update((list) => list.filter((t) => t.id !== id));
+    this._items.update((list) => list.filter((t) => t.id !== id));
   }
 
   pause(id: string): void {
-    const item = this.items().find((t) => t.id === id);
+    const item = this._items().find((t) => t.id === id);
     if (!item || item.duration === 0) return;
     this.clearTimer(id);
     const remaining = item.duration - (Date.now() - item.startedAt);
-    this.items.update((list) =>
+    this._items.update((list) =>
       list.map((t) => (t.id === id ? { ...t, remainingMs: Math.max(remaining, 0) } : t)),
     );
   }
 
   resume(id: string): void {
-    const item = this.items().find((t) => t.id === id);
+    const item = this._items().find((t) => t.id === id);
     if (!item || item.duration === 0 || item.state === 'exiting') return;
     const remaining = item.remainingMs ?? item.duration;
-    this.items.update((list) =>
+    this._items.update((list) =>
       list.map((t) => (t.id === id ? { ...t, startedAt: Date.now(), remainingMs: undefined } : t)),
     );
     this.startTimer(id, remaining);
@@ -106,7 +107,7 @@ export class ToastService {
   _testReset(): void {
     for (const timer of this.timers.values()) clearTimeout(timer);
     this.timers.clear();
-    this.items.set([]);
+    this._items.set([]);
   }
 
   private startTimer(id: string, ms: number): void {
@@ -129,7 +130,7 @@ export class ToastService {
   }
 
   private enforceMaxLimit(): void {
-    const active = this.items().filter((t) => t.state !== 'exiting');
+    const active = this._items().filter((t) => t.state !== 'exiting');
     if (active.length <= MAX_VISIBLE) return;
     const toRemove = active.slice(0, active.length - MAX_VISIBLE);
     for (const item of toRemove) {

--- a/apps/web/src/app/core/workspace-selection/workspace-selection.service.ts
+++ b/apps/web/src/app/core/workspace-selection/workspace-selection.service.ts
@@ -6,15 +6,17 @@ export interface SelectionToggleOptions {
 
 @Injectable({ providedIn: 'root' })
 export class WorkspaceSelectionService {
-  readonly selectedMediaIds = signal<Set<string>>(new Set());
-  readonly selectedCount = computed(() => this.selectedMediaIds().size);
+  private readonly _selectedMediaIds = signal<Set<string>>(new Set());
+  readonly selectedMediaIds = this._selectedMediaIds.asReadonly();
+
+  readonly selectedCount = computed(() => this._selectedMediaIds().size);
 
   isSelected(id: string): boolean {
-    return this.selectedMediaIds().has(id);
+    return this._selectedMediaIds().has(id);
   }
 
   toggle(id: string, options: SelectionToggleOptions): void {
-    this.selectedMediaIds.update((existing) => {
+    this._selectedMediaIds.update((existing) => {
       const next = new Set(existing);
       if (options.additive) {
         if (next.has(id)) {
@@ -34,14 +36,14 @@ export class WorkspaceSelectionService {
   }
 
   setSingle(id: string): void {
-    this.selectedMediaIds.set(new Set([id]));
+    this._selectedMediaIds.set(new Set([id]));
   }
 
   selectAllInScope(scopeIds: string[]): void {
-    this.selectedMediaIds.set(new Set(scopeIds));
+    this._selectedMediaIds.set(new Set(scopeIds));
   }
 
   clearSelection(): void {
-    this.selectedMediaIds.set(new Set());
+    this._selectedMediaIds.set(new Set());
   }
 }

--- a/apps/web/src/app/core/workspace-view/workspace-view.service.spec.ts
+++ b/apps/web/src/app/core/workspace-view/workspace-view.service.spec.ts
@@ -282,7 +282,7 @@ describe('WorkspaceViewService â€” grouping with addresses', () => {
       makeImage({ id: 'c', district: 'Seefeld' }),
     ];
     service.setActiveSelectionImages(images);
-    service.activeGroupings.set([{ id: 'district', label: 'District', icon: '' }]);
+    service.setActiveGroupings([{ id: 'district', label: 'District', icon: '' }]);
 
     const sections = service.groupedSections();
     expect(sections.length).toBe(2);
@@ -297,7 +297,7 @@ describe('WorkspaceViewService â€” grouping with addresses', () => {
 
     const images = [makeImage({ id: 'a', district: null })];
     service.setActiveSelectionImages(images);
-    service.activeGroupings.set([{ id: 'district', label: 'District', icon: '' }]);
+    service.setActiveGroupings([{ id: 'district', label: 'District', icon: '' }]);
 
     const sections = service.groupedSections();
     expect(sections[0].heading).toBe('Unknown district');
@@ -308,7 +308,7 @@ describe('WorkspaceViewService â€” grouping with addresses', () => {
 
     const images = [makeImage({ id: 'a', city: 'ZÃ¼rich' }), makeImage({ id: 'b', city: 'Bern' })];
     service.setActiveSelectionImages(images);
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: '' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: '' }]);
 
     const sections = service.groupedSections();
     expect(sections.length).toBe(2);
@@ -363,7 +363,7 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
   it('auto-prepends grouping keys to effectiveSorts', () => {
     const service = setupSortGrouping();
 
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
 
     const effective = service.effectiveSorts();
     expect(effective[0]).toEqual({ key: 'city', direction: 'asc' });
@@ -374,7 +374,7 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
   it('groups are sorted alphabetically when grouping direction is asc', () => {
     const service = setupSortGrouping();
 
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
 
     const sections = service.groupedSections();
     const headings = sections.map((s) => s.heading);
@@ -384,9 +384,9 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
   it('groups are sorted reverse-alphabetically when grouping direction is desc', () => {
     const service = setupSortGrouping();
 
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
     // Change city sort direction to descending
-    service.activeSorts.set([
+    service.setActiveSorts([
       { key: 'city', direction: 'desc' },
       { key: 'date-captured', direction: 'desc' },
     ]);
@@ -399,7 +399,7 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
   it('multi-level grouping respects sort directions for both levels', () => {
     const service = setupSortGrouping();
 
-    service.activeGroupings.set([
+    service.setActiveGroupings([
       { id: 'city', label: 'City', icon: 'location_city' },
       { id: 'project', label: 'Project', icon: 'folder' },
     ]);
@@ -417,13 +417,13 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
     const service = setupSortGrouping();
 
     // User first activates city sort as descending
-    service.activeSorts.set([
+    service.setActiveSorts([
       { key: 'date-captured', direction: 'desc' },
       { key: 'city', direction: 'desc' },
     ]);
 
     // Then city is added as a grouping
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
 
     const effective = service.effectiveSorts();
     // City should be first (grouping position) and retain desc direction
@@ -434,11 +434,11 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
     const service = setupSortGrouping();
 
     // Activate grouping â€” city gets auto-added to sorts
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
     expect(service.effectiveSorts().some((s) => s.key === 'city')).toBe(true);
 
     // Remove the grouping
-    service.activeGroupings.set([]);
+    service.setActiveGroupings([]);
 
     const effective = service.effectiveSorts();
     // City was grouping-only â€” should be gone
@@ -451,16 +451,16 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
     const service = setupSortGrouping();
 
     // User explicitly adds city sort first
-    service.activeSorts.set([
+    service.setActiveSorts([
       { key: 'date-captured', direction: 'desc' },
       { key: 'city', direction: 'asc' },
     ]);
 
     // Then grouping is added for city
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
 
     // Then grouping is removed
-    service.activeGroupings.set([]);
+    service.setActiveGroupings([]);
 
     const effective = service.effectiveSorts();
     // City was in user sorts before grouping â€” should remain
@@ -471,13 +471,13 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
     const service = setupSortGrouping();
 
     // User has city in their sorts
-    service.activeSorts.set([
+    service.setActiveSorts([
       { key: 'date-captured', direction: 'desc' },
       { key: 'city', direction: 'desc' },
     ]);
 
     // Add city as grouping
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
 
     const effective = service.effectiveSorts();
     // City should appear exactly once (at grouping position)
@@ -489,7 +489,7 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
   it('images within a group are sorted by remaining sort keys', () => {
     const service = setupSortGrouping();
 
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
     // Default: date-captured desc â€” within Berlin group, b1 (March) should come before b2 (Jan)
 
     const sections = service.groupedSections();
@@ -501,14 +501,14 @@ describe('WorkspaceViewService â€” sort + grouping sync', () => {
   it('changing sort direction on grouped property reorders groups', () => {
     const service = setupSortGrouping();
 
-    service.activeGroupings.set([{ id: 'city', label: 'City', icon: 'location_city' }]);
+    service.setActiveGroupings([{ id: 'city', label: 'City', icon: 'location_city' }]);
 
     // Verify initial Aâ†’Z order
     let sections = service.groupedSections();
     expect(sections[0].heading).toBe('Berlin');
 
     // Change city to descending
-    service.activeSorts.set([
+    service.setActiveSorts([
       { key: 'city', direction: 'desc' },
       { key: 'date-captured', direction: 'desc' },
     ]);
@@ -535,7 +535,7 @@ describe('WorkspaceViewService â€” numeric sorting', () => {
       makeImage({ id: 'd', metadata: { fang: '1' } }),
     ];
     service.setActiveSelectionImages(images);
-    service.activeSorts.set([{ key: 'fang', direction: 'asc' }]);
+    service.setActiveSorts([{ key: 'fang', direction: 'asc' }]);
 
     const sorted = service.groupedSections()[0].images;
     // Numeric order: 1, 5, 12, 100 (not lexicographic "1", "100", "12", "5")
@@ -554,7 +554,7 @@ describe('WorkspaceViewService â€” numeric sorting', () => {
       makeImage({ id: 'c', metadata: { fang: '12' } }),
     ];
     service.setActiveSelectionImages(images);
-    service.activeSorts.set([{ key: 'fang', direction: 'desc' }]);
+    service.setActiveSorts([{ key: 'fang', direction: 'desc' }]);
 
     const sorted = service.groupedSections()[0].images;
     expect(sorted.map((i) => i.id)).toEqual(['b', 'c', 'a']);
@@ -572,7 +572,7 @@ describe('WorkspaceViewService â€” numeric sorting', () => {
       makeImage({ id: 'c', metadata: { fang: '1' } }),
     ];
     service.setActiveSelectionImages(images);
-    service.activeSorts.set([{ key: 'fang', direction: 'asc' }]);
+    service.setActiveSorts([{ key: 'fang', direction: 'asc' }]);
 
     const sorted = service.groupedSections()[0].images;
     expect(sorted[0].id).toBe('c'); // 1
@@ -592,7 +592,7 @@ describe('WorkspaceViewService â€” numeric sorting', () => {
       makeImage({ id: 'c', metadata: { floor: '1' } }),
     ];
     service.setActiveSelectionImages(images);
-    service.activeGroupings.set([{ id: 'floor', label: 'Floor', icon: 'numbers' }]);
+    service.setActiveGroupings([{ id: 'floor', label: 'Floor', icon: 'numbers' }]);
 
     const sections = service.groupedSections();
     expect(sections.length).toBe(2);
@@ -783,7 +783,7 @@ describe('WorkspaceViewService â€” loadCustomProperties integration', () =>
     service.setActiveSelectionImages(images);
 
     // Step 3: Group by Bauphase
-    service.activeGroupings.set([{ id: 'uuid-bauphase', label: 'Bauphase', icon: 'tag' }]);
+    service.setActiveGroupings([{ id: 'uuid-bauphase', label: 'Bauphase', icon: 'tag' }]);
 
     // Step 4: Verify groups
     const sections = service.groupedSections();
@@ -841,7 +841,7 @@ describe('WorkspaceViewService â€” loadCustomProperties integration', () =>
     service.setActiveSelectionImages(images);
 
     // Step 3: Sort by Fang ascending
-    service.activeSorts.set([{ key: 'uuid-fang', direction: 'asc' }]);
+    service.setActiveSorts([{ key: 'uuid-fang', direction: 'asc' }]);
 
     // Step 4: Verify text-type sort (since DB has no key_type, defaults to text)
     // Text sort ascending: '100' < '12' < '5' (lexicographic)

--- a/apps/web/src/app/core/workspace-view/workspace-view.service.ts
+++ b/apps/web/src/app/core/workspace-view/workspace-view.service.ts
@@ -26,15 +26,30 @@ export class WorkspaceViewService {
 
   // Ã¢â€â‚¬Ã¢â€â‚¬ Input signals Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
-  readonly rawImages = signal<WorkspaceImage[]>([]);
-  readonly selectedProjectIds = signal<Set<string>>(new Set());
-  readonly activeSorts = signal<SortConfig[]>(DEFAULT_SORTS);
-  readonly activeGroupings = signal<MetadataFieldRef[]>([]);
-  readonly thumbnailSizePreset = signal<ThumbnailSizePreset>(this.readThumbnailSizePreset());
-  readonly collapsedGroups = signal<Set<string>>(new Set());
-  readonly isLoading = signal(false);
+  private readonly _rawImages = signal<WorkspaceImage[]>([]);
+  readonly rawImages = this._rawImages.asReadonly();
+
+  private readonly _selectedProjectIds = signal<Set<string>>(new Set());
+  readonly selectedProjectIds = this._selectedProjectIds.asReadonly();
+
+  private readonly _activeSorts = signal<SortConfig[]>(DEFAULT_SORTS);
+  readonly activeSorts = this._activeSorts.asReadonly();
+
+  private readonly _activeGroupings = signal<MetadataFieldRef[]>([]);
+  readonly activeGroupings = this._activeGroupings.asReadonly();
+
+  private readonly _thumbnailSizePreset = signal<ThumbnailSizePreset>(this.readThumbnailSizePreset());
+  readonly thumbnailSizePreset = this._thumbnailSizePreset.asReadonly();
+
+  private readonly _collapsedGroups = signal<Set<string>>(new Set());
+  readonly collapsedGroups = this._collapsedGroups.asReadonly();
+
+  private readonly _isLoading = signal(false);
+  readonly isLoading = this._isLoading.asReadonly();
+
   /** True once a marker click triggers a load Ã¢â‚¬â€ distinguishes "no selection" from "empty result". */
-  readonly selectionActive = signal(false);
+  private readonly _selectionActive = signal(false);
+  readonly selectionActive = this._selectionActive.asReadonly();
 
   // Ã¢â€â‚¬Ã¢â€â‚¬ Pipeline: computed signal chain Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
@@ -44,8 +59,8 @@ export class WorkspaceViewService {
    * moved to the grouping position. New grouping keys default to ascending.
    */
   readonly effectiveSorts = computed<SortConfig[]>(() => {
-    const groupings = this.activeGroupings();
-    const userSorts = this.activeSorts();
+    const groupings = this._activeGroupings();
+    const userSorts = this._activeSorts();
 
     if (groupings.length === 0) return userSorts;
 
@@ -66,8 +81,8 @@ export class WorkspaceViewService {
 
   /** Step 1: Filter by project. Empty set = no filter (all projects). */
   private readonly projectFiltered = computed(() => {
-    const images = this.rawImages();
-    const projectIds = this.selectedProjectIds();
+    const images = this._rawImages();
+    const projectIds = this._selectedProjectIds();
     if (projectIds.size === 0) return images;
     return images.filter((img) => {
       const ids = img.projectIds?.length ? img.projectIds : img.projectId ? [img.projectId] : [];
@@ -115,7 +130,7 @@ export class WorkspaceViewService {
   /** Step 4: Group by active groupings (multi-level). */
   readonly groupedSections = computed<GroupedSection[]>(() => {
     const images = this.sorted();
-    const groupings = this.activeGroupings();
+    const groupings = this._activeGroupings();
     if (groupings.length === 0) {
       return [{ heading: '', headingLevel: 0, imageCount: images.length, images }];
     }
@@ -145,13 +160,13 @@ export class WorkspaceViewService {
     zoom: number,
   ): Promise<void> {
     const requestId = ++this.clusterLoadId;
-    this.selectionActive.set(true);
-    this.isLoading.set(true);
+    this._selectionActive.set(true);
+    this._isLoading.set(true);
     try {
       const images = await this.fetchClusterImages(cells, zoom);
       if (requestId !== this.clusterLoadId) return;
 
-      this.rawImages.set(images);
+      this._rawImages.set(images);
       if (images.length > 0) {
         this.resolveUnresolvedAddresses(images);
         void this.batchSignThumbnails(images);
@@ -159,7 +174,7 @@ export class WorkspaceViewService {
       }
     } finally {
       if (requestId === this.clusterLoadId) {
-        this.isLoading.set(false);
+        this._isLoading.set(false);
       }
     }
   }
@@ -240,8 +255,8 @@ export class WorkspaceViewService {
 
   /** Set images directly (e.g. from a radius selection). */
   setActiveSelectionImages(images: WorkspaceImage[]): void {
-    this.selectionActive.set(true);
-    this.rawImages.set(images);
+    this._selectionActive.set(true);
+    this._rawImages.set(images);
     this.resolveUnresolvedAddresses(images);
     void this.batchSignThumbnails(images);
     void this.loadMetadataValues(images);
@@ -394,29 +409,29 @@ export class WorkspaceViewService {
 
   /** Convenience: "select" state populated but holding zero rows (RPC returned nothing). */
   readonly emptySelection = computed(
-    () => this.selectionActive() && !this.isLoading() && this.rawImages().length === 0,
+    () => this._selectionActive() && !this._isLoading() && this._rawImages().length === 0,
   );
 
   /** Clear active selection data only Ã¢â‚¬â€ preserves toolbar settings (sort, filters, project, grouping). */
   clearActiveSelection(): void {
-    this.rawImages.set([]);
-    this.selectionActive.set(false);
-    this.collapsedGroups.set(new Set());
+    this._rawImages.set([]);
+    this._selectionActive.set(false);
+    this._collapsedGroups.set(new Set());
   }
 
   /** Clear active selection AND reset all toolbar settings to defaults. */
   clearActiveSelectionAndSettings(): void {
-    this.rawImages.set([]);
-    this.selectionActive.set(false);
-    this.selectedProjectIds.set(new Set());
+    this._rawImages.set([]);
+    this._selectionActive.set(false);
+    this._selectedProjectIds.set(new Set());
     this.filterService.clearAll();
-    this.activeSorts.set(DEFAULT_SORTS);
-    this.activeGroupings.set([]);
-    this.collapsedGroups.set(new Set());
+    this._activeSorts.set(DEFAULT_SORTS);
+    this._activeGroupings.set([]);
+    this._collapsedGroups.set(new Set());
   }
 
   toggleGroupCollapsed(groupKey: string): void {
-    this.collapsedGroups.update((set) => {
+    this._collapsedGroups.update((set) => {
       const next = new Set(set);
       if (next.has(groupKey)) {
         next.delete(groupKey);
@@ -428,8 +443,24 @@ export class WorkspaceViewService {
   }
 
   setThumbnailSizePreset(preset: ThumbnailSizePreset): void {
-    this.thumbnailSizePreset.set(preset);
+    this._thumbnailSizePreset.set(preset);
     this.persistThumbnailSizePreset(preset);
+  }
+
+  setSelectedProjectIds(projectIds: Set<string>): void {
+    this._selectedProjectIds.set(projectIds);
+  }
+
+  setActiveSorts(sorts: SortConfig[]): void {
+    this._activeSorts.set(sorts);
+  }
+
+  setActiveGroupings(groupings: MetadataFieldRef[]): void {
+    this._activeGroupings.set(groupings);
+  }
+
+  updateRawImages(updater: (images: WorkspaceImage[]) => WorkspaceImage[]): void {
+    this._rawImages.update(updater);
   }
 
   /** Batch-sign thumbnail URLs for a set of images. */
@@ -455,7 +486,7 @@ export class WorkspaceViewService {
     const attemptedIds = new Set(unsigned.map((img) => img.id));
 
     // Update signal: apply URLs or mark unavailable.
-    this.rawImages.update((all) =>
+    this._rawImages.update((all) =>
       all.map((img) => {
         const result = results.get(img.id);
         if (result?.url) return { ...img, signedThumbnailUrl: result.url };
@@ -477,7 +508,7 @@ export class WorkspaceViewService {
     const results = await this.locationResolver.resolveOnDemand(images);
     if (results.size === 0) return;
 
-    this.rawImages.update((all) =>
+    this._rawImages.update((all) =>
       all.map((existing) => {
         const resolved = results.get(existing.id);
         return resolved
@@ -521,7 +552,7 @@ export class WorkspaceViewService {
     const metadataMap = await this.metadata.loadMetadataValuesByLookupIds(lookupIds);
     if (metadataMap.size === 0) return;
 
-    this.rawImages.update((all) =>
+    this._rawImages.update((all) =>
       all.map((img) => {
         const values = metadataMap.get(img.id);
         return values ? { ...img, metadata: { ...img.metadata, ...values } } : img;

--- a/apps/web/src/app/features/map/map-shell/map-context-actions.service.ts
+++ b/apps/web/src/app/features/map/map-shell/map-context-actions.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import type * as L from 'leaflet';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import { GeocodingService } from '../../../core/geocoding/geocoding.service';
+import { SupabaseService } from '../../../core/supabase/supabase.service';
 import type { WorkspaceImage } from '../../../core/workspace-view/workspace-view.types';
 
 export interface AssignImagesToProjectResult {
@@ -10,8 +10,15 @@ export interface AssignImagesToProjectResult {
   errorMessage?: string;
 }
 
+export interface RemoveImagesFromProjectsResult {
+  ok: boolean;
+  reason: 'success' | 'empty' | 'lookup-error' | 'remove-error';
+  errorMessage?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class MapContextActionsService {
+  private readonly supabaseService = inject(SupabaseService);
   private readonly geocodingService = inject(GeocodingService);
 
   clampContextMenuPosition(x: number, y: number): { x: number; y: number } {
@@ -77,7 +84,6 @@ export class MapContextActionsService {
   }
 
   async assignImagesToProject(
-    client: SupabaseClient,
     mediaIds: string[],
     projectId: string,
   ): Promise<AssignImagesToProjectResult> {
@@ -85,34 +91,57 @@ export class MapContextActionsService {
       return { ok: false, reason: 'empty' };
     }
 
-    const { data: mediaRows, error: mediaLookupError } = await client
-      .from('media_items')
-      .select('id,source_image_id')
-      .or(`id.in.(${mediaIds.join(',')}),source_image_id.in.(${mediaIds.join(',')})`);
-
-    if (mediaLookupError) {
-      return { ok: false, reason: 'error', errorMessage: mediaLookupError.message };
+    const resolvedMediaItems = await this.resolveMediaItemIds(mediaIds);
+    if (!resolvedMediaItems.ok) {
+      return { ok: false, reason: 'error', errorMessage: resolvedMediaItems.errorMessage };
     }
 
-    const mediaItemIds = Array.from(
-      new Set((mediaRows ?? []).map((row: { id: string }) => row.id).filter(Boolean)),
-    );
-
-    if (mediaItemIds.length === 0) {
+    if (resolvedMediaItems.mediaItemIds.length === 0) {
       return { ok: false, reason: 'empty' };
     }
 
-    const membershipPayload = mediaItemIds.map((mediaItemId) => ({
+    const membershipPayload = resolvedMediaItems.mediaItemIds.map((mediaItemId) => ({
       media_item_id: mediaItemId,
       project_id: projectId,
     }));
 
-    const { error: membershipError } = await client
+    const { error: membershipError } = await this.supabaseService.client
       .from('media_projects')
       .upsert(membershipPayload, { onConflict: 'media_item_id,project_id' });
 
     if (membershipError) {
       return { ok: false, reason: 'error', errorMessage: membershipError.message };
+    }
+
+    return { ok: true, reason: 'success' };
+  }
+
+  async removeImagesFromProjects(mediaIds: string[]): Promise<RemoveImagesFromProjectsResult> {
+    const uniqueMediaIds = Array.from(new Set(mediaIds));
+    if (uniqueMediaIds.length === 0) {
+      return { ok: false, reason: 'empty' };
+    }
+
+    const resolvedMediaItems = await this.resolveMediaItemIds(uniqueMediaIds);
+    if (!resolvedMediaItems.ok) {
+      return {
+        ok: false,
+        reason: 'lookup-error',
+        errorMessage: resolvedMediaItems.errorMessage,
+      };
+    }
+
+    if (resolvedMediaItems.mediaItemIds.length === 0) {
+      return { ok: false, reason: 'empty' };
+    }
+
+    const { error: removeError } = await this.supabaseService.client
+      .from('media_projects')
+      .delete()
+      .in('media_item_id', resolvedMediaItems.mediaItemIds);
+
+    if (removeError) {
+      return { ok: false, reason: 'remove-error', errorMessage: removeError.message };
     }
 
     return { ok: true, reason: 'success' };
@@ -136,5 +165,26 @@ export class MapContextActionsService {
 
     const images = await fetchClusterImages(payload.sourceCells, zoom);
     return images.map((img) => img.id);
+  }
+
+  private async resolveMediaItemIds(
+    mediaIds: string[],
+  ): Promise<{ ok: true; mediaItemIds: string[] } | { ok: false; errorMessage: string }> {
+    const idList = Array.from(new Set(mediaIds)).join(',');
+    const { data: mediaRows, error: mediaLookupError } = await this.supabaseService.client
+      .from('media_items')
+      .select('id,source_image_id')
+      .or(`id.in.(${idList}),source_image_id.in.(${idList})`);
+
+    if (mediaLookupError) {
+      return { ok: false, errorMessage: mediaLookupError.message };
+    }
+
+    return {
+      ok: true,
+      mediaItemIds: Array.from(
+        new Set((mediaRows ?? []).map((row: { id: string }) => row.id).filter(Boolean)),
+      ),
+    };
   }
 }

--- a/apps/web/src/app/features/map/map-shell/map-leaflet.service.ts
+++ b/apps/web/src/app/features/map/map-shell/map-leaflet.service.ts
@@ -1,0 +1,112 @@
+import { Injectable } from '@angular/core';
+import * as L from 'leaflet';
+import {
+  PHOTO_MARKER_ICON_ANCHOR,
+  PHOTO_MARKER_ICON_SIZE,
+  PHOTO_MARKER_POPUP_ANCHOR,
+} from '../../../core/map/marker-factory';
+
+export type MapInstance = L.Map;
+export type MapMarker = L.Marker;
+export type MapLayerGroup = L.LayerGroup;
+export type MapTileLayer = L.TileLayer;
+export type MapLatLng = L.LatLng;
+export type MapLatLngBounds = L.LatLngBounds;
+export type MapPoint = L.Point;
+export type MapPolyline = L.Polyline;
+export type MapCircle = L.Circle;
+export type MapDivIcon = L.DivIcon;
+export type MapMouseEvent = L.LeafletMouseEvent;
+
+@Injectable({ providedIn: 'root' })
+export class MapLeafletService {
+  createMap(container: HTMLElement): MapInstance {
+    return L.map(container, {
+      center: [48.2082, 16.3738], // Vienna, Austria (fallback)
+      zoom: 13,
+      maxZoom: 22,
+      zoomControl: false,
+    });
+  }
+
+  createPhotoMarkerLayer(map: MapInstance): MapLayerGroup {
+    return L.layerGroup().addTo(map);
+  }
+
+  createLatLng(lat: number, lng: number): MapLatLng {
+    return L.latLng(lat, lng);
+  }
+
+  createBounds(southWest: [number, number], northEast: [number, number]): MapLatLngBounds {
+    return L.latLngBounds(southWest, northEast);
+  }
+
+  createRadiusDraftLine(map: MapInstance, startLatLng: MapLatLng): MapPolyline {
+    return L.polyline([startLatLng, startLatLng], {
+      color: 'var(--color-clay)',
+      weight: 2,
+      opacity: 0.95,
+      dashArray: '6 4',
+      interactive: false,
+    }).addTo(map);
+  }
+
+  createRadiusDraftCircle(map: MapInstance, startLatLng: MapLatLng): MapCircle {
+    return L.circle(startLatLng, {
+      radius: 1,
+      color: 'var(--color-clay)',
+      weight: 2,
+      opacity: 0.95,
+      fillColor: 'var(--color-clay)',
+      fillOpacity: 0.1,
+      interactive: false,
+    }).addTo(map);
+  }
+
+  createUserLocationMarker(coords: [number, number]): MapMarker {
+    return L.marker(coords, {
+      icon: L.divIcon({
+        className: 'map-user-location-marker',
+        iconSize: [18, 18],
+        iconAnchor: [9, 9],
+      }),
+      interactive: false,
+      keyboard: false,
+      zIndexOffset: 2000,
+    });
+  }
+
+  createSearchLocationMarker(coords: [number, number]): MapMarker {
+    return L.marker(coords, {
+      icon: L.divIcon({
+        className: 'map-search-location-marker',
+        iconSize: [20, 20],
+        iconAnchor: [10, 10],
+      }),
+      interactive: false,
+      keyboard: false,
+    });
+  }
+
+  createPhotoMarker(coords: [number, number], icon: MapDivIcon): MapMarker {
+    return L.marker(coords, { icon });
+  }
+
+  createStaticPhotoMarker(coords: [number, number], icon: MapDivIcon): MapMarker {
+    return L.marker(coords, {
+      icon,
+      interactive: false,
+      keyboard: false,
+    });
+  }
+
+  createPhotoMarkerIcon(html: string): MapDivIcon {
+    return L.divIcon({
+      className: 'map-photo-marker-wrapper',
+      html,
+      iconSize: PHOTO_MARKER_ICON_SIZE,
+      iconAnchor: PHOTO_MARKER_ICON_ANCHOR,
+      popupAnchor: PHOTO_MARKER_POPUP_ANCHOR,
+    });
+  }
+}

--- a/apps/web/src/app/features/map/map-shell/map-project-actions.service.ts
+++ b/apps/web/src/app/features/map/map-shell/map-project-actions.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseService } from '../../../core/supabase/supabase.service';
 import type { ProjectSelectOption } from '../../../shared/project-select-dialog/project-select-dialog.component';
 
 export interface CreateProjectFromImageResult {
@@ -23,6 +24,8 @@ export interface ProjectAssignmentResultLike {
 
 @Injectable({ providedIn: 'root' })
 export class MapProjectActionsService {
+  private readonly supabaseService = inject(SupabaseService);
+
   getAssignmentFailureMessage(result: ProjectAssignmentResultLike): string | null {
     if (result.ok) {
       return null;
@@ -41,10 +44,15 @@ export class MapProjectActionsService {
       : `${imageCount} Medien dem Projekt "${projectName}" zugewiesen.`;
   }
 
-  async loadProjectOptions(client: SupabaseClient): Promise<LoadProjectOptionsResult> {
-    const { data, error } = await client.from('projects').select('id,name').order('name', {
-      ascending: true,
-    });
+  async loadProjectOptions(): Promise<LoadProjectOptionsResult>;
+  async loadProjectOptions(_client: SupabaseClient): Promise<LoadProjectOptionsResult>;
+  async loadProjectOptions(_client?: SupabaseClient): Promise<LoadProjectOptionsResult> {
+    const { data, error } = await this.supabaseService.client
+      .from('projects')
+      .select('id,name')
+      .order('name', {
+        ascending: true,
+      });
 
     if (error) {
       return { ok: false, reason: 'error', options: [] };
@@ -72,19 +80,15 @@ export class MapProjectActionsService {
   }
 
   async createProjectFromFirstImage(params: {
-    client: SupabaseClient;
     projectName: string;
     firstImageId: string;
   }): Promise<CreateProjectFromImageResult> {
-    const organizationId = await this.resolveOrganizationIdForImage(
-      params.client,
-      params.firstImageId,
-    );
+    const organizationId = await this.resolveOrganizationIdForImage(params.firstImageId);
     if (!organizationId) {
       return { ok: false, reason: 'organization-missing' };
     }
 
-    const { data: projectData, error: projectError } = await params.client
+    const { data: projectData, error: projectError } = await this.supabaseService.client
       .from('projects')
       .insert({ name: params.projectName, organization_id: organizationId })
       .select('id,name')
@@ -108,11 +112,8 @@ export class MapProjectActionsService {
     };
   }
 
-  private async resolveOrganizationIdForImage(
-    client: SupabaseClient,
-    mediaId: string,
-  ): Promise<string | null> {
-    const { data, error } = await client
+  private async resolveOrganizationIdForImage(mediaId: string): Promise<string | null> {
+    const { data, error } = await this.supabaseService.client
       .from('media_items')
       .select('organization_id')
       .or(`id.eq.${mediaId},source_image_id.eq.${mediaId}`)

--- a/apps/web/src/app/features/map/map-shell/map-project-dialog.service.ts
+++ b/apps/web/src/app/features/map/map-shell/map-project-dialog.service.ts
@@ -1,17 +1,18 @@
-import type { WritableSignal } from '@angular/core';
+import type { Signal } from '@angular/core';
 import { Injectable } from '@angular/core';
 import type { ProjectSelectOption } from '../../../shared/project-select-dialog/project-select-dialog.component';
 
 interface ProjectDialogSignals {
-  projectSelectionDialogOpen: WritableSignal<boolean>;
-  projectSelectionDialogTitle: WritableSignal<string>;
-  projectSelectionDialogMessage: WritableSignal<string>;
-  projectSelectionDialogOptions: WritableSignal<ReadonlyArray<ProjectSelectOption>>;
-  projectSelectionDialogSelectedId: WritableSignal<string | null>;
-  projectNameDialogOpen: WritableSignal<boolean>;
-  projectNameDialogTitle: WritableSignal<string>;
-  projectNameDialogMessage: WritableSignal<string>;
-  projectNameDialogInitialValue: WritableSignal<string>;
+  projectSelectionDialogOptions: Signal<ReadonlyArray<ProjectSelectOption>>;
+  setProjectSelectionDialogOpen(value: boolean): void;
+  setProjectSelectionDialogTitle(value: string): void;
+  setProjectSelectionDialogMessage(value: string): void;
+  setProjectSelectionDialogOptions(value: ReadonlyArray<ProjectSelectOption>): void;
+  setProjectSelectionDialogSelectedId(value: string | null): void;
+  setProjectNameDialogOpen(value: boolean): void;
+  setProjectNameDialogTitle(value: string): void;
+  setProjectNameDialogMessage(value: string): void;
+  setProjectNameDialogInitialValue(value: string): void;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -29,11 +30,11 @@ export class MapProjectDialogService {
   ): Promise<{ id: string; name: string } | null> {
     this.resolveProjectSelection(signals, null);
 
-    signals.projectSelectionDialogOptions.set(options);
-    signals.projectSelectionDialogTitle.set(title);
-    signals.projectSelectionDialogMessage.set(message);
-    signals.projectSelectionDialogSelectedId.set(options.length > 0 ? options[0].id : null);
-    signals.projectSelectionDialogOpen.set(true);
+    signals.setProjectSelectionDialogOptions(options);
+    signals.setProjectSelectionDialogTitle(title);
+    signals.setProjectSelectionDialogMessage(message);
+    signals.setProjectSelectionDialogSelectedId(options.length > 0 ? options[0].id : null);
+    signals.setProjectSelectionDialogOpen(true);
 
     return new Promise((resolve) => {
       this.projectSelectionDialogResolver = resolve;
@@ -41,7 +42,7 @@ export class MapProjectDialogService {
   }
 
   setProjectSelectionSelectedId(signals: ProjectDialogSignals, projectId: string): void {
-    signals.projectSelectionDialogSelectedId.set(projectId);
+    signals.setProjectSelectionDialogSelectedId(projectId);
   }
 
   confirmProjectSelection(signals: ProjectDialogSignals, projectId: string): void {
@@ -67,10 +68,10 @@ export class MapProjectDialogService {
     message: string,
   ): Promise<string | null> {
     this.resolveProjectName(signals, null);
-    signals.projectNameDialogTitle.set(title);
-    signals.projectNameDialogMessage.set(message);
-    signals.projectNameDialogInitialValue.set(initialValue);
-    signals.projectNameDialogOpen.set(true);
+    signals.setProjectNameDialogTitle(title);
+    signals.setProjectNameDialogMessage(message);
+    signals.setProjectNameDialogInitialValue(initialValue);
+    signals.setProjectNameDialogOpen(true);
 
     return new Promise((resolve) => {
       this.projectNameDialogResolver = resolve;
@@ -96,9 +97,9 @@ export class MapProjectDialogService {
   ): void {
     const resolver = this.projectSelectionDialogResolver;
     this.projectSelectionDialogResolver = null;
-    signals.projectSelectionDialogOpen.set(false);
-    signals.projectSelectionDialogOptions.set([]);
-    signals.projectSelectionDialogSelectedId.set(null);
+    signals.setProjectSelectionDialogOpen(false);
+    signals.setProjectSelectionDialogOptions([]);
+    signals.setProjectSelectionDialogSelectedId(null);
     if (resolver) {
       resolver(value);
     }
@@ -107,7 +108,7 @@ export class MapProjectDialogService {
   private resolveProjectName(signals: ProjectDialogSignals, value: string | null): void {
     const resolver = this.projectNameDialogResolver;
     this.projectNameDialogResolver = null;
-    signals.projectNameDialogOpen.set(false);
+    signals.setProjectNameDialogOpen(false);
     if (resolver) {
       resolver(value);
     }

--- a/apps/web/src/app/features/map/map-shell/map-shell.component.spec.ts
+++ b/apps/web/src/app/features/map/map-shell/map-shell.component.spec.ts
@@ -46,15 +46,15 @@ function createJsonResponse(body: unknown, status = 200): Response {
 function createWorkspacePaneShellHostStub(state: MapShellState): WorkspacePaneShellHost {
   return {
     openDetailView(mediaId: string): void {
-      state.photoPanelOpen.set(true);
-      state.detailMediaId.set(mediaId);
+      state.setPhotoPanelOpen(true);
+      state.setDetailMediaId(mediaId);
     },
     closeDetailView(): void {
-      state.detailMediaId.set(null);
+      state.setDetailMediaId(null);
     },
     closeWorkspacePane(): void {
-      state.photoPanelOpen.set(false);
-      state.detailMediaId.set(null);
+      state.setPhotoPanelOpen(false);
+      state.setDetailMediaId(null);
     },
     onWorkspaceWidthChange(_newWidth: number): void {},
     onWorkspacePaneActiveTabChange(_tab: WorkspacePaneTab): void {},
@@ -353,9 +353,9 @@ describe('MapShellComponent', () => {
       .spyOn(workspaceView, 'clearActiveSelection')
       .mockImplementation(() => {});
 
-    component.selectedMarkerKey.set('cluster-1');
-    component.selectedMarkerKeys.set(new Set(['cluster-1', 'cluster-2']));
-    component.detailMediaId.set('img-1');
+    TestBed.inject(MapShellState).setSelectedMarkerKey('cluster-1');
+    TestBed.inject(MapShellState).setSelectedMarkerKeys(new Set(['cluster-1', 'cluster-2']));
+    TestBed.inject(MapShellState).setDetailMediaId('img-1');
     component.clearRadiusSelectionVisuals = vi.fn();
 
     component.handleMapClick({
@@ -384,8 +384,8 @@ describe('MapShellComponent', () => {
       }) => void;
     };
 
-    component.selectedMarkerKey.set('cluster-1');
-    component.selectedMarkerKeys.set(new Set(['cluster-1', 'cluster-2']));
+    TestBed.inject(MapShellState).setSelectedMarkerKey('cluster-1');
+    TestBed.inject(MapShellState).setSelectedMarkerKeys(new Set(['cluster-1', 'cluster-2']));
     component.suppressMapClickUntil = Date.now() + 60_000;
 
     component.handleMapClick({
@@ -787,7 +787,7 @@ describe('MapShellComponent', () => {
     fixture.detectChanges();
 
     const workspaceView = TestBed.inject(WorkspaceViewService);
-    workspaceView.rawImages.set([
+    workspaceView.setActiveSelectionImages([
       {
         id: 'img-1',
         latitude: 48.8566,
@@ -1072,20 +1072,20 @@ describe('MapShellComponent', () => {
       anyContextMenuOpen: () => boolean;
     };
 
-    component.mapContextMenuOpen.set(false);
-    component.radiusContextMenuOpen.set(false);
-    component.markerContextMenuOpen.set(false);
+    TestBed.inject(MapShellState).setMapContextMenuOpen(false);
+    TestBed.inject(MapShellState).setRadiusContextMenuOpen(false);
+    TestBed.inject(MapShellState).setMarkerContextMenuOpen(false);
     expect(component.anyContextMenuOpen()).toBe(false);
 
-    component.mapContextMenuOpen.set(true);
+    TestBed.inject(MapShellState).setMapContextMenuOpen(true);
     expect(component.anyContextMenuOpen()).toBe(true);
 
-    component.mapContextMenuOpen.set(false);
-    component.radiusContextMenuOpen.set(true);
+    TestBed.inject(MapShellState).setMapContextMenuOpen(false);
+    TestBed.inject(MapShellState).setRadiusContextMenuOpen(true);
     expect(component.anyContextMenuOpen()).toBe(true);
 
-    component.radiusContextMenuOpen.set(false);
-    component.markerContextMenuOpen.set(true);
+    TestBed.inject(MapShellState).setRadiusContextMenuOpen(false);
+    TestBed.inject(MapShellState).setMarkerContextMenuOpen(true);
     expect(component.anyContextMenuOpen()).toBe(true);
   });
 
@@ -1103,7 +1103,7 @@ describe('MapShellComponent', () => {
       onMapContextCreateMarkerHere: () => void;
     };
 
-    component.mapContextMenuCoords.set({ lat: 48.2, lng: 16.37 });
+    TestBed.inject(MapShellState).setMapContextMenuCoords({ lat: 48.2, lng: 16.37 });
     component.onMapContextCreateMarkerHere();
 
     expect(component.draftMediaMarker()).toEqual({ lat: 48.2, lng: 16.37, uploadCount: 0 });
@@ -1129,8 +1129,8 @@ describe('MapShellComponent', () => {
     };
 
     component.map = mapStub;
-    component.mapContextMenuOpen.set(true);
-    component.mapContextMenuCoords.set({ lat: 48.2, lng: 16.37 });
+    TestBed.inject(MapShellState).setMapContextMenuOpen(true);
+    TestBed.inject(MapShellState).setMapContextMenuCoords({ lat: 48.2, lng: 16.37 });
 
     component.onMapContextZoomStreetHere();
 
@@ -1149,7 +1149,7 @@ describe('MapShellComponent', () => {
 
     const focusSpy = vi.fn();
     component.mapContainerRef = () => ({ nativeElement: { focus: focusSpy } });
-    component.mapContextMenuOpen.set(true);
+    TestBed.inject(MapShellState).setMapContextMenuOpen(true);
 
     component.onMapMenuCloseRequested();
 
@@ -1187,8 +1187,12 @@ describe('MapShellComponent', () => {
       }) => void;
     };
 
-    component.draftMediaMarker.set({ lat: 48.2, lng: 16.37, uploadCount: 0 });
-    component.photoPanelOpen.set(true);
+    TestBed.inject(MapShellState).setDraftMediaMarker({
+      lat: 48.2,
+      lng: 16.37,
+      uploadCount: 0,
+    });
+    TestBed.inject(MapShellState).setPhotoPanelOpen(true);
 
     component.handleMapClick({
       latlng: { lat: 48.21, lng: 16.38 },
@@ -1459,7 +1463,7 @@ describe('MapShellComponent', () => {
       sourceCells: [{ lat: 48.2007, lng: 16.3707 }],
     });
 
-    component.selectedMarkerKeys.set(new Set(['single-1', 'single-2']));
+    TestBed.inject(MapShellState).setSelectedMarkerKeys(new Set(['single-1', 'single-2']));
     component.openMarkerContextMenu('single-1', { clientX: 220, clientY: 240 });
 
     expect(component.markerContextMenuPayload()?.isMultiSelection).toBe(true);
@@ -1484,7 +1488,11 @@ describe('MapShellComponent', () => {
       enterPlacementMode: (key: string) => void;
     };
 
-    component.draftMediaMarker.set({ lat: 48.2, lng: 16.37, uploadCount: 0 });
+    TestBed.inject(MapShellState).setDraftMediaMarker({
+      lat: 48.2,
+      lng: 16.37,
+      uploadCount: 0,
+    });
     component.uploadPanelChild = () => ({ placeFile });
 
     component.enterPlacementMode('job-1');
@@ -1620,10 +1628,10 @@ describe('MapShellComponent', () => {
       lng: 16.35,
       sourceCells: [{ lat: 48.25, lng: 16.35 }],
     });
-    component.selectedMarkerKeys.set(new Set(['already-selected']));
+    TestBed.inject(MapShellState).setSelectedMarkerKeys(new Set(['already-selected']));
 
     const workspaceView = TestBed.inject(WorkspaceViewService);
-    workspaceView.rawImages.set([
+    workspaceView.setActiveSelectionImages([
       {
         id: 'img-existing',
         latitude: 48.25,
@@ -1812,7 +1820,7 @@ describe('MapShellComponent', () => {
     });
 
     const workspaceView = TestBed.inject(WorkspaceViewService);
-    workspaceView.rawImages.set([
+    workspaceView.setActiveSelectionImages([
       {
         id: 'img-existing',
         latitude: 48.25,
@@ -1905,7 +1913,7 @@ describe('MapShellComponent', () => {
     });
 
     const workspaceView = TestBed.inject(WorkspaceViewService);
-    workspaceView.rawImages.set([]);
+    workspaceView.setActiveSelectionImages([]);
 
     vi.spyOn(workspaceView, 'fetchClusterImages').mockResolvedValue([
       {
@@ -1951,7 +1959,7 @@ describe('MapShellComponent', () => {
     });
 
     const workspaceView = TestBed.inject(WorkspaceViewService);
-    workspaceView.rawImages.set([
+    workspaceView.setActiveSelectionImages([
       {
         id: 'img-hovered',
         latitude: 48.2,
@@ -2059,7 +2067,7 @@ describe('MapShellComponent', () => {
     const fixture = TestBed.createComponent(MapShellComponent);
     fixture.detectChanges();
 
-    fixture.componentInstance.photoPanelOpen.set(true);
+    TestBed.inject(MapShellState).setPhotoPanelOpen(true);
     fixture.detectChanges();
 
     expect(fixture.componentInstance.photoPanelOpen()).toBe(true);
@@ -2073,7 +2081,7 @@ describe('MapShellComponent', () => {
     const fixture = TestBed.createComponent(MapShellComponent);
     fixture.detectChanges();
 
-    fixture.componentInstance.photoPanelOpen.set(true);
+    TestBed.inject(MapShellState).setPhotoPanelOpen(true);
     fixture.detectChanges();
 
     const panelShell = (fixture.nativeElement as HTMLElement).querySelector(

--- a/apps/web/src/app/features/map/map-shell/map-shell.component.ts
+++ b/apps/web/src/app/features/map/map-shell/map-shell.component.ts
@@ -30,7 +30,6 @@ import {
   viewChild,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import * as L from 'leaflet';
 import { UploadPanelComponent } from '../../upload/upload-panel.component';
 import type {
   ImageUploadedEvent,
@@ -38,7 +37,6 @@ import type {
   UploadLocationPreviewEvent,
 } from '../../../core/workspace-pane/workspace-pane-shell-events.types';
 import { ExifCoords } from '../../../core/upload/upload.service';
-import { SupabaseService } from '../../../core/supabase/supabase.service';
 import { GeocodingService } from '../../../core/geocoding/geocoding.service';
 import {
   UploadManagerService,
@@ -71,9 +69,7 @@ import { ResolvedAction } from '../../../core/action/action-types';
 import { fileTypeBadge } from '../../../core/media/file-type-registry';
 import {
   buildPhotoMarkerHtml,
-  PHOTO_MARKER_ICON_ANCHOR,
   PHOTO_MARKER_ICON_SIZE,
-  PHOTO_MARKER_POPUP_ANCHOR,
   PhotoMarkerZoomLevel,
 } from '../../../core/map/marker-factory';
 import { MapShellState } from './map-shell.state';
@@ -92,13 +88,30 @@ import { RadiusSelectionService } from './radius-selection.service';
 import { ZoomTargetMarkerService } from './zoom-target-marker.service';
 import { RadiusCommittedVisual, RadiusVisualsService } from './radius-visuals.service';
 import { RadiusDraftHighlightService } from './radius-draft-highlight.service';
-import { MapContextActionsService } from './map-context-actions.service';
+import {
+  MapContextActionsService,
+  type RemoveImagesFromProjectsResult,
+} from './map-context-actions.service';
 import { MarkerContextPhotoDeleteService } from './marker-context-photo-delete.service';
 import { PhotoMarkerIconStateService } from './photo-marker-icon-state.service';
 import { MarkerSelectionSyncService } from './marker-selection-sync.service';
 import { MarkerMotionService } from './marker-motion.service';
 import { MapBasemapPreference, MapPreferencesService } from './map-preferences.service';
 import { MapBasemapLayerService } from './map-basemap-layer.service';
+import {
+  MapCircle,
+  MapDivIcon,
+  MapInstance,
+  MapLatLng,
+  MapLatLngBounds,
+  MapLayerGroup,
+  MapMarker,
+  MapMouseEvent,
+  MapPoint,
+  MapPolyline,
+  MapTileLayer,
+  MapLeafletService,
+} from './map-leaflet.service';
 import { MapFocusPayloadService } from './map-focus-payload.service';
 import { ShareTokenSelectionService } from './share-token-selection.service';
 import { MapGeolocationService } from './map-geolocation.service';
@@ -221,7 +234,6 @@ export class MapShellComponent implements OnDestroy {
   private static readonly MAP_SAFE_MIN_WIDTH = 320;
 
   readonly placeholderIconUrl = `url("${MEDIA_PLACEHOLDER_ICON}")`;
-  private readonly supabaseService = inject(SupabaseService);
   private readonly geocodingService = inject(GeocodingService);
   private readonly uploadManagerService = inject(UploadManagerService);
   private readonly workspaceViewService = inject(WorkspaceViewService);
@@ -250,6 +262,7 @@ export class MapShellComponent implements OnDestroy {
   private readonly markerSelectionSyncService = inject(MarkerSelectionSyncService);
   private readonly mapPreferencesService = inject(MapPreferencesService);
   private readonly mapBasemapLayerService = inject(MapBasemapLayerService);
+  private readonly mapLeafletService = inject(MapLeafletService);
   private readonly mapFocusPayloadService = inject(MapFocusPayloadService);
   private readonly shareTokenSelectionService = inject(ShareTokenSelectionService);
   private readonly mapGeolocationService = inject(MapGeolocationService);
@@ -280,7 +293,7 @@ export class MapShellComponent implements OnDestroy {
    * Leaflet map instance. Protected (not private) so unit tests can inject
    * a mock to test behaviour without initialising the real Leaflet map.
    */
-  protected map?: L.Map;
+  protected map?: MapInstance;
 
   // ── Upload / placement state ─────────────────────────────────────────────
 
@@ -578,9 +591,9 @@ export class MapShellComponent implements OnDestroy {
 
   // ── Private helpers ───────────────────────────────────────────────────────
 
-  private userLocationMarker: L.Marker | null = null;
-  private searchLocationMarker: L.Marker | null = null;
-  private draftMediaMarkerLeaflet: L.Marker | null = null;
+  private userLocationMarker: MapMarker | null = null;
+  private searchLocationMarker: MapMarker | null = null;
+  private draftMediaMarkerLeaflet: MapMarker | null = null;
   private readonly uploadedPhotoMarkers = new Map<
     string,
     PhotoMarkerState & {
@@ -610,19 +623,19 @@ export class MapShellComponent implements OnDestroy {
   private lastZoomLevel: PhotoMarkerZoomLevel = 'mid';
 
   /** LayerGroup for all photo markers — enables batch add/remove. */
-  private photoMarkerLayer: L.LayerGroup | null = null;
-  private activeBaseTileLayer: L.TileLayer | null = null;
-  private radiusDrawStartLatLng: L.LatLng | null = null;
+  private photoMarkerLayer: MapLayerGroup | null = null;
+  private activeBaseTileLayer: MapTileLayer | null = null;
+  private radiusDrawStartLatLng: MapLatLng | null = null;
   private radiusDrawActive = false;
   private radiusDrawAdditive = false;
-  private radiusDraftLine: L.Polyline | null = null;
-  private radiusDraftCircle: L.Circle | null = null;
-  private radiusDraftLabel: L.Marker | null = null;
-  private radiusDrawMoveHandler: ((event: L.LeafletMouseEvent) => void) | null = null;
-  private radiusDrawMouseUpHandler: ((event: L.LeafletMouseEvent) => void) | null = null;
+  private radiusDraftLine: MapPolyline | null = null;
+  private radiusDraftCircle: MapCircle | null = null;
+  private radiusDraftLabel: MapMarker | null = null;
+  private radiusDrawMoveHandler: ((event: MapMouseEvent) => void) | null = null;
+  private radiusDrawMouseUpHandler: ((event: MapMouseEvent) => void) | null = null;
   private pendingSecondaryPress: {
-    startPoint: L.Point;
-    startLatLng: L.LatLng;
+    startPoint: MapPoint;
+    startLatLng: MapLatLng;
     startClientX: number;
     startClientY: number;
     additive: boolean;
@@ -639,7 +652,7 @@ export class MapShellComponent implements OnDestroy {
    * Bounds that were last fetched (including 10% buffer).
    * Used to skip RPC when the viewport is still within the buffered area.
    */
-  private lastFetchedBounds: L.LatLngBounds | null = null;
+  private lastFetchedBounds: MapLatLngBounds | null = null;
   private lastFetchedZoom: number | null = null;
 
   /** True while a zoom animation is in progress — suppresses moveend queries. */
@@ -842,9 +855,9 @@ export class MapShellComponent implements OnDestroy {
   }
 
   closeContextMenus(): void {
-    this.mapContextMenuOpen.set(false);
-    this.radiusContextMenuOpen.set(false);
-    this.markerContextMenuOpen.set(false);
+    this.state.setMapContextMenuOpen(false);
+    this.state.setRadiusContextMenuOpen(false);
+    this.state.setMarkerContextMenuOpen(false);
   }
 
   onMapMenuCloseRequested(): void {
@@ -900,14 +913,14 @@ export class MapShellComponent implements OnDestroy {
   onMapContextCreateMarkerHere(): void {
     const coords = this.mapContextMenuCoords();
     if (!coords) return;
-    this.draftMediaMarker.set({ lat: coords.lat, lng: coords.lng, uploadCount: 0 });
+    this.state.setDraftMediaMarker({ lat: coords.lat, lng: coords.lng, uploadCount: 0 });
     this.renderOrUpdateDraftMediaMarker([coords.lat, coords.lng]);
     this.searchPlacementActive.set(false);
     this.placementActive.set(false);
     if (!this.photoPanelOpen()) {
-      this.workspacePaneWidth.set(this.getWorkspacePaneOpeningWidth());
+      this.state.setWorkspacePaneWidth(this.getWorkspacePaneOpeningWidth());
     }
-    this.photoPanelOpen.set(true);
+    this.state.setPhotoPanelOpen(true);
     this.patchDetailMediaId(null);
     this.setSelectedMarker(null);
     this.setSelectedMarkerKeys(new Set());
@@ -1024,7 +1037,7 @@ export class MapShellComponent implements OnDestroy {
     const coords = this.mapContextMenuCoords();
     if (!coords || !this.map) return;
 
-    const center = L.latLng(coords.lat, coords.lng);
+    const center = this.mapLeafletService.createLatLng(coords.lat, coords.lng);
     const radiusMeters = MapShellComponent.QUICK_RADIUS_METERS;
     const edge = this.radiusVisualsService.offsetLatLngEast(center, radiusMeters);
 
@@ -1053,7 +1066,6 @@ export class MapShellComponent implements OnDestroy {
     }
 
     const created = await this.mapProjectActionsService.createProjectFromFirstImage({
-      client: this.supabaseService.client,
       projectName,
       firstImageId: mediaIds[0],
     });
@@ -1076,7 +1088,6 @@ export class MapShellComponent implements OnDestroy {
     }
 
     const assigned = await this.mapContextActionsService.assignImagesToProject(
-      this.supabaseService.client,
       mediaIds,
       created.project.id,
     );
@@ -1118,11 +1129,7 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    const assigned = await this.mapContextActionsService.assignImagesToProject(
-      this.supabaseService.client,
-      mediaIds,
-      project.id,
-    );
+    const assigned = await this.mapContextActionsService.assignImagesToProject(mediaIds, project.id);
     const assignFailureMessage =
       this.mapProjectActionsService.getAssignmentFailureMessage(assigned);
     if (!assignFailureMessage) {
@@ -1181,44 +1188,11 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    const idList = uniqueImageIds.join(',');
-    const { data: mediaRows, error: mediaLookupError } = await this.supabaseService.client
-      .from('media_items')
-      .select('id,source_image_id')
-      .or(`id.in.(${idList}),source_image_id.in.(${idList})`);
-
-    if (mediaLookupError) {
+    const removed = await this.mapContextActionsService.removeImagesFromProjects(uniqueImageIds);
+    if (!removed.ok) {
       this.toastService.show({
-        message: 'Projektzuordnungen konnten nicht geladen werden.',
-        type: 'error',
-        dedupe: true,
-      });
-      this.onMapMenuCloseRequested();
-      return;
-    }
-
-    const mediaItemIds = Array.from(
-      new Set((mediaRows ?? []).map((row: { id: string }) => row.id).filter(Boolean)),
-    );
-    if (mediaItemIds.length === 0) {
-      this.toastService.show({
-        message: 'Keine Projektzuordnungen gefunden.',
-        type: 'warning',
-        dedupe: true,
-      });
-      this.onMapMenuCloseRequested();
-      return;
-    }
-
-    const { error: removeError } = await this.supabaseService.client
-      .from('media_projects')
-      .delete()
-      .in('media_item_id', mediaItemIds);
-
-    if (removeError) {
-      this.toastService.show({
-        message: 'Entfernen aus Projekten ist fehlgeschlagen.',
-        type: 'error',
+        message: this.getRemoveImagesFromProjectsFailureMessage(removed),
+        type: removed.reason === 'empty' ? 'warning' : 'error',
         dedupe: true,
       });
       this.onMapMenuCloseRequested();
@@ -1253,10 +1227,7 @@ export class MapShellComponent implements OnDestroy {
     let deletedCount = 0;
     let failedCount = 0;
     for (const mediaId of uniqueImageIds) {
-      const deleted = await this.markerContextPhotoDeleteService.deleteImageById(
-        this.supabaseService.client,
-        mediaId,
-      );
+      const deleted = await this.markerContextPhotoDeleteService.deleteImageById(mediaId);
       if (!deleted.ok) {
         failedCount += 1;
         continue;
@@ -1396,12 +1367,12 @@ export class MapShellComponent implements OnDestroy {
     }
 
     if (mediaIds.length > 1) {
-      this.state.batchAddressDialogTitle.set('Adresse fuer Auswahl aendern');
-      this.state.batchAddressDialogMessage.set(
+      this.state.setBatchAddressDialogTitle('Adresse fuer Auswahl aendern');
+      this.state.setBatchAddressDialogMessage(
         `${mediaIds.length} Medien erhalten dieselbe Adresse.`,
       );
-      this.state.batchAddressTargetMediaIds.set(mediaIds);
-      this.state.batchAddressDialogOpen.set(true);
+      this.state.setBatchAddressTargetMediaIds(mediaIds);
+      this.state.setBatchAddressDialogOpen(true);
       this.onMapMenuCloseRequested();
       return;
     }
@@ -1410,7 +1381,7 @@ export class MapShellComponent implements OnDestroy {
 
     this.openDetailView(mediaId);
     const currentRequestId = this.detailAddressSearchRequest()?.requestId ?? 0;
-    this.detailAddressSearchRequest.set({ mediaId, requestId: currentRequestId + 1 });
+    this.state.setDetailAddressSearchRequest({ mediaId, requestId: currentRequestId + 1 });
     this.onMapMenuCloseRequested();
   }
 
@@ -1460,8 +1431,8 @@ export class MapShellComponent implements OnDestroy {
   }
 
   onBatchAddressDialogCancelled(): void {
-    this.state.batchAddressDialogOpen.set(false);
-    this.state.batchAddressTargetMediaIds.set([]);
+    this.state.setBatchAddressDialogOpen(false);
+    this.state.setBatchAddressTargetMediaIds([]);
   }
 
   async onBatchAddressDialogConfirmed(addressInput: string): Promise<void> {
@@ -1551,11 +1522,7 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    const assigned = await this.mapContextActionsService.assignImagesToProject(
-      this.supabaseService.client,
-      mediaIds,
-      project.id,
-    );
+    const assigned = await this.mapContextActionsService.assignImagesToProject(mediaIds, project.id);
     const assignFailureMessage =
       this.mapProjectActionsService.getAssignmentFailureMessage(assigned);
     if (assignFailureMessage) {
@@ -1656,44 +1623,11 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    const idList = uniqueImageIds.join(',');
-    const { data: mediaRows, error: mediaLookupError } = await this.supabaseService.client
-      .from('media_items')
-      .select('id,source_image_id')
-      .or(`id.in.(${idList}),source_image_id.in.(${idList})`);
-
-    if (mediaLookupError) {
+    const removed = await this.mapContextActionsService.removeImagesFromProjects(uniqueImageIds);
+    if (!removed.ok) {
       this.toastService.show({
-        message: 'Projektzuordnungen konnten nicht geladen werden.',
-        type: 'error',
-        dedupe: true,
-      });
-      this.onMapMenuCloseRequested();
-      return;
-    }
-
-    const mediaItemIds = Array.from(
-      new Set((mediaRows ?? []).map((row: { id: string }) => row.id).filter(Boolean)),
-    );
-    if (mediaItemIds.length === 0) {
-      this.toastService.show({
-        message: 'Keine Projektzuordnungen gefunden.',
-        type: 'warning',
-        dedupe: true,
-      });
-      this.onMapMenuCloseRequested();
-      return;
-    }
-
-    const { error: removeError } = await this.supabaseService.client
-      .from('media_projects')
-      .delete()
-      .in('media_item_id', mediaItemIds);
-
-    if (removeError) {
-      this.toastService.show({
-        message: 'Entfernen aus Projekten ist fehlgeschlagen.',
-        type: 'error',
+        message: this.getRemoveImagesFromProjectsFailureMessage(removed),
+        type: removed.reason === 'empty' ? 'warning' : 'error',
         dedupe: true,
       });
       this.onMapMenuCloseRequested();
@@ -1741,10 +1675,7 @@ export class MapShellComponent implements OnDestroy {
       let deletedCount = 0;
       let failedCount = 0;
       for (const mediaId of uniqueImageIds) {
-        const deleted = await this.markerContextPhotoDeleteService.deleteImageById(
-          this.supabaseService.client,
-          mediaId,
-        );
+        const deleted = await this.markerContextPhotoDeleteService.deleteImageById(mediaId);
         if (!deleted.ok) {
           failedCount += 1;
           continue;
@@ -1781,10 +1712,7 @@ export class MapShellComponent implements OnDestroy {
     const target = this.markerContextPhotoDeleteService.getSingleImageTarget(payload);
     if (!target || !this.markerContextPhotoDeleteService.confirmPhotoDelete()) return;
 
-    const deleted = await this.markerContextPhotoDeleteService.deleteImageById(
-      this.supabaseService.client,
-      target.mediaId,
-    );
+    const deleted = await this.markerContextPhotoDeleteService.deleteImageById(target.mediaId);
     if (!deleted.ok) {
       this.toastService.show({
         message: deleted.errorMessage ?? 'Loeschen fehlgeschlagen.',
@@ -1842,7 +1770,7 @@ export class MapShellComponent implements OnDestroy {
   }
 
   private patchDetailMediaId(mediaId: string | null): void {
-    this.state.detailMediaId.set(mediaId);
+    this.state.setDetailMediaId(mediaId);
     this.workspacePaneObserver.setDetailImageId(mediaId);
   }
 
@@ -2198,28 +2126,23 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    this.map = L.map(containerRef.nativeElement, {
-      center: [48.2082, 16.3738], // Vienna, Austria (fallback)
-      zoom: 13,
-      maxZoom: 22,
-      zoomControl: false,
-    });
+    this.map = this.mapLeafletService.createMap(containerRef.nativeElement);
 
     this.applyMapBasemapLayer();
 
     // LayerGroup for all photo markers — batch add/remove.
-    this.photoMarkerLayer = L.layerGroup().addTo(this.map);
+    this.photoMarkerLayer = this.mapLeafletService.createPhotoMarkerLayer(this.map);
 
     this.updateSearchViewportBounds();
     this.applyPendingMapFocus();
 
     // Map click handler: closes upload panel and, when active, places images
     // that had no GPS EXIF data.
-    this.map.on('click', (e: L.LeafletMouseEvent) => this.handleMapClick(e));
-    this.map.on('mousedown', (e: L.LeafletMouseEvent) => this.handleMapMouseDown(e));
-    this.map.on('mousemove', (e: L.LeafletMouseEvent) => this.handleMapMouseMove(e));
-    this.map.on('mouseup', (e: L.LeafletMouseEvent) => this.handleMapMouseUp(e));
-    this.map.on('contextmenu', (e: L.LeafletMouseEvent) => this.handleMapContextMenu(e));
+    this.map.on('click', (e: MapMouseEvent) => this.handleMapClick(e));
+    this.map.on('mousedown', (e: MapMouseEvent) => this.handleMapMouseDown(e));
+    this.map.on('mousemove', (e: MapMouseEvent) => this.handleMapMouseMove(e));
+    this.map.on('mouseup', (e: MapMouseEvent) => this.handleMapMouseUp(e));
+    this.map.on('contextmenu', (e: MapMouseEvent) => this.handleMapContextMenu(e));
 
     // Capture-phase suppression ensures the native browser menu never opens
     // above the custom app context menu.
@@ -2386,9 +2309,9 @@ export class MapShellComponent implements OnDestroy {
       this.searchPlacementActive.set(false);
       this.placementActive.set(false);
       if (!this.photoPanelOpen()) {
-        this.workspacePaneWidth.set(this.getWorkspacePaneOpeningWidth());
+        this.state.setWorkspacePaneWidth(this.getWorkspacePaneOpeningWidth());
       }
-      this.photoPanelOpen.set(true);
+      this.state.setPhotoPanelOpen(true);
 
       this.toastService.show({
         message: `${result.selectionIds.length} Medien aus Freigabelink geladen.`,
@@ -2414,7 +2337,7 @@ export class MapShellComponent implements OnDestroy {
     return true;
   }
 
-  private handleMapClick(e: L.LeafletMouseEvent): void {
+  private handleMapClick(e: MapMouseEvent): void {
     this.closeContextMenus();
 
     const clickButton = e.originalEvent?.button ?? 0;
@@ -2473,7 +2396,7 @@ export class MapShellComponent implements OnDestroy {
     return true;
   }
 
-  private tryCompletePendingPlacement(latlng: L.LatLng): boolean {
+  private tryCompletePendingPlacement(latlng: MapLatLng): boolean {
     if (!this.pendingPlacementKey) {
       return false;
     }
@@ -2507,7 +2430,7 @@ export class MapShellComponent implements OnDestroy {
     this.clearRadiusSelectionVisuals();
   }
 
-  private completeSearchPlacement(latlng: L.LatLng): void {
+  private completeSearchPlacement(latlng: MapLatLng): void {
     this.renderOrUpdateSearchLocationMarker([latlng.lat, latlng.lng]);
     const pendingUploadLocation = this.pendingUploadedLocationMapPick;
     this.pendingUploadedLocationMapPick = null;
@@ -2552,7 +2475,7 @@ export class MapShellComponent implements OnDestroy {
     });
   }
 
-  private handleMapMouseDown(event: L.LeafletMouseEvent): void {
+  private handleMapMouseDown(event: MapMouseEvent): void {
     if (event.originalEvent.button !== 2) {
       return;
     }
@@ -2572,7 +2495,7 @@ export class MapShellComponent implements OnDestroy {
     this.closeContextMenus();
   }
 
-  private handleMapMouseMove(event: L.LeafletMouseEvent): void {
+  private handleMapMouseMove(event: MapMouseEvent): void {
     if (!this.map || !this.pendingSecondaryPress || this.radiusDrawActive) {
       return;
     }
@@ -2592,7 +2515,7 @@ export class MapShellComponent implements OnDestroy {
     this.updateRadiusSelectionDraft(event.latlng);
   }
 
-  private handleMapMouseUp(event: L.LeafletMouseEvent): void {
+  private handleMapMouseUp(event: MapMouseEvent): void {
     if (event.originalEvent.button !== 2) {
       return;
     }
@@ -2620,7 +2543,7 @@ export class MapShellComponent implements OnDestroy {
     this.openContextMenuForShortSecondaryClick(startLatLng, startClientX, startClientY);
   }
 
-  private handleMapContextMenu(event: L.LeafletMouseEvent): void {
+  private handleMapContextMenu(event: MapMouseEvent): void {
     if (this.consumeNativeContextMenuBypass()) {
       return;
     }
@@ -2650,7 +2573,7 @@ export class MapShellComponent implements OnDestroy {
   }
 
   private openContextMenuForShortSecondaryClick(
-    latlng: L.LatLng,
+    latlng: MapLatLng,
     clientX: number,
     clientY: number,
   ): void {
@@ -2720,7 +2643,7 @@ export class MapShellComponent implements OnDestroy {
     return !!target.closest('.map-photo-marker, .leaflet-marker-icon');
   }
 
-  private startRadiusSelectionDraw(startLatLng: L.LatLng, additive: boolean): void {
+  private startRadiusSelectionDraw(startLatLng: MapLatLng, additive: boolean): void {
     if (!this.map || this.placementActive() || this.searchPlacementActive()) {
       return;
     }
@@ -2733,33 +2656,19 @@ export class MapShellComponent implements OnDestroy {
     this.radiusDrawStartLatLng = startLatLng;
     this.suppressMapClickUntil = Date.now() + MapShellComponent.RADIUS_CLICK_GUARD_MS;
 
-    this.radiusDraftLine = L.polyline([startLatLng, startLatLng], {
-      color: 'var(--color-clay)',
-      weight: 2,
-      opacity: 0.95,
-      dashArray: '6 4',
-      interactive: false,
-    }).addTo(this.map);
+    this.radiusDraftLine = this.mapLeafletService.createRadiusDraftLine(this.map, startLatLng);
 
-    this.radiusDraftCircle = L.circle(startLatLng, {
-      radius: 1,
-      color: 'var(--color-clay)',
-      weight: 2,
-      opacity: 0.95,
-      fillColor: 'var(--color-clay)',
-      fillOpacity: 0.1,
-      interactive: false,
-    }).addTo(this.map);
+    this.radiusDraftCircle = this.mapLeafletService.createRadiusDraftCircle(this.map, startLatLng);
 
     this.radiusDraftLabel = this.radiusVisualsService
       .createLabelMarker(startLatLng, 0, 0)
       .addTo(this.map);
 
-    this.radiusDrawMoveHandler = (moveEvent: L.LeafletMouseEvent) => {
+    this.radiusDrawMoveHandler = (moveEvent: MapMouseEvent) => {
       this.updateRadiusSelectionDraft(moveEvent.latlng);
     };
 
-    this.radiusDrawMouseUpHandler = (upEvent: L.LeafletMouseEvent) => {
+    this.radiusDrawMouseUpHandler = (upEvent: MapMouseEvent) => {
       void this.commitRadiusSelection(upEvent.latlng);
     };
 
@@ -2767,7 +2676,7 @@ export class MapShellComponent implements OnDestroy {
     this.map.on('mouseup', this.radiusDrawMouseUpHandler);
   }
 
-  private updateRadiusSelectionDraft(currentLatLng: L.LatLng): void {
+  private updateRadiusSelectionDraft(currentLatLng: MapLatLng): void {
     if (!this.map || !this.radiusDrawStartLatLng) {
       return;
     }
@@ -2790,7 +2699,7 @@ export class MapShellComponent implements OnDestroy {
     this.updateRadiusDraftMarkerHighlights(this.radiusDrawStartLatLng, radiusMeters);
   }
 
-  private async commitRadiusSelection(endLatLng: L.LatLng): Promise<void> {
+  private async commitRadiusSelection(endLatLng: MapLatLng): Promise<void> {
     if (!this.map || !this.radiusDrawStartLatLng) {
       this.cancelRadiusDrawing();
       return;
@@ -2844,7 +2753,7 @@ export class MapShellComponent implements OnDestroy {
     }
   }
 
-  private updateRadiusDraftMarkerHighlights(center: L.LatLng, radiusMeters: number): void {
+  private updateRadiusDraftMarkerHighlights(center: MapLatLng, radiusMeters: number): void {
     if (!this.map) {
       return;
     }
@@ -2894,7 +2803,7 @@ export class MapShellComponent implements OnDestroy {
     this.radiusVisualsService.clearCommittedSelectionVisuals(this.radiusCommittedVisuals);
   }
 
-  private addRadiusSelectionVisual(center: L.LatLng, radiusMeters: number, edge: L.LatLng): void {
+  private addRadiusSelectionVisual(center: MapLatLng, radiusMeters: number, edge: MapLatLng): void {
     if (!this.map) return;
 
     this.radiusCommittedVisuals.push(
@@ -2903,7 +2812,7 @@ export class MapShellComponent implements OnDestroy {
   }
 
   private async selectRadiusImages(
-    center: L.LatLng,
+    center: MapLatLng,
     radiusMeters: number,
     additive: boolean,
   ): Promise<void> {
@@ -2929,9 +2838,9 @@ export class MapShellComponent implements OnDestroy {
     }
 
     if (!this.photoPanelOpen()) {
-      this.workspacePaneWidth.set(this.getWorkspacePaneOpeningWidth());
+      this.state.setWorkspacePaneWidth(this.getWorkspacePaneOpeningWidth());
     }
-    this.photoPanelOpen.set(true);
+    this.state.setPhotoPanelOpen(true);
     this.patchDetailMediaId(null);
     this.setSelectedMarker(null);
   }
@@ -2940,18 +2849,7 @@ export class MapShellComponent implements OnDestroy {
     if (!this.map) return;
 
     if (!this.userLocationMarker) {
-      const icon = L.divIcon({
-        className: 'map-user-location-marker',
-        iconSize: [18, 18],
-        iconAnchor: [9, 9],
-      });
-
-      this.userLocationMarker = L.marker(coords, {
-        icon,
-        interactive: false,
-        keyboard: false,
-        zIndexOffset: 2000,
-      });
+      this.userLocationMarker = this.mapLeafletService.createUserLocationMarker(coords);
 
       try {
         this.userLocationMarker.addTo(this.map);
@@ -2992,17 +2890,7 @@ export class MapShellComponent implements OnDestroy {
     if (!this.map) return;
 
     if (!this.searchLocationMarker) {
-      const icon = L.divIcon({
-        className: 'map-search-location-marker',
-        iconSize: [20, 20],
-        iconAnchor: [10, 10],
-      });
-
-      this.searchLocationMarker = L.marker(coords, {
-        icon,
-        interactive: false,
-        keyboard: false,
-      });
+      this.searchLocationMarker = this.mapLeafletService.createSearchLocationMarker(coords);
 
       try {
         this.searchLocationMarker.addTo(this.map);
@@ -3023,11 +2911,7 @@ export class MapShellComponent implements OnDestroy {
 
     const icon = this.buildDraftMediaMarkerIcon();
     if (!this.draftMediaMarkerLeaflet) {
-      this.draftMediaMarkerLeaflet = L.marker(coords, {
-        icon,
-        interactive: false,
-        keyboard: false,
-      });
+      this.draftMediaMarkerLeaflet = this.mapLeafletService.createStaticPhotoMarker(coords, icon);
 
       try {
         if (this.photoMarkerLayer) {
@@ -3048,18 +2932,14 @@ export class MapShellComponent implements OnDestroy {
     this.draftMediaMarkerLeaflet.setIcon(icon);
   }
 
-  private buildDraftMediaMarkerIcon(): L.DivIcon {
-    return L.divIcon({
-      className: 'map-photo-marker-wrapper',
-      html: buildPhotoMarkerHtml({
+  private buildDraftMediaMarkerIcon(): MapDivIcon {
+    return this.mapLeafletService.createPhotoMarkerIcon(
+      buildPhotoMarkerHtml({
         count: 1,
         selected: true,
         zoomLevel: this.getPhotoMarkerZoomLevel(),
       }),
-      iconSize: PHOTO_MARKER_ICON_SIZE,
-      iconAnchor: PHOTO_MARKER_ICON_ANCHOR,
-      popupAnchor: PHOTO_MARKER_POPUP_ANCHOR,
-    });
+    );
   }
 
   private removeDraftMediaMarker(): void {
@@ -3071,7 +2951,7 @@ export class MapShellComponent implements OnDestroy {
       }
       this.draftMediaMarkerLeaflet = null;
     }
-    this.draftMediaMarker.set(null);
+    this.state.setDraftMediaMarker(null);
   }
 
   private resolveDraftMediaMarkerUpload(event: ImageUploadedEvent): void {
@@ -3189,20 +3069,21 @@ export class MapShellComponent implements OnDestroy {
 
       if (nextCount > 1 && this.selectedMarkerKey() === markerKey) {
         this.setSelectedMarker(null);
-        this.photoPanelOpen.set(false);
+        this.state.setPhotoPanelOpen(false);
       }
 
       existing.marker.setIcon(this.buildPhotoMarkerIcon(markerKey));
       return;
     }
 
-    const marker = L.marker([event.lat, event.lng], {
-      icon: this.buildPhotoMarkerIcon(markerKey, {
+    const marker = this.mapLeafletService.createPhotoMarker(
+      [event.lat, event.lng],
+      this.buildPhotoMarkerIcon(markerKey, {
         count: 1,
         thumbnailUrl: event.thumbnailUrl,
         direction: event.direction,
       }),
-    });
+    );
 
     this.photoMarkerLayer!.addLayer(marker);
     this.attachMarkerInteractions(markerKey, marker);
@@ -3239,7 +3120,6 @@ export class MapShellComponent implements OnDestroy {
     this.viewportQueryController = controller;
 
     const result = await this.viewportMarkerQueryService.fetchViewportMarkers<ViewportMarkerRow>(
-      this.supabaseService.client,
       this.map,
       controller.signal,
     );
@@ -3249,7 +3129,7 @@ export class MapShellComponent implements OnDestroy {
     this.viewportQueryController = null;
 
     // Cache the fetched bounds so small pans can skip the RPC.
-    this.lastFetchedBounds = L.latLngBounds(
+    this.lastFetchedBounds = this.mapLeafletService.createBounds(
       [result.fetchSouth, result.fetchWest],
       [result.fetchNorth, result.fetchEast],
     );
@@ -3292,7 +3172,7 @@ export class MapShellComponent implements OnDestroy {
       !this.uploadedPhotoMarkers.has(this.linkedHoverMarkerFromMapKey)
     ) {
       this.setLinkedHoverMarkerFromMap(null);
-      this.linkedHoveredWorkspaceMediaIds.set(new Set());
+      this.state.setLinkedHoveredWorkspaceMediaIds(new Set());
     }
   }
 
@@ -3333,7 +3213,8 @@ export class MapShellComponent implements OnDestroy {
       uploadedPhotoMarkers: this.uploadedPhotoMarkers,
       markersByMediaId: this.markersByMediaId,
       selectedMarkerKey: () => this.selectedMarkerKey(),
-      setSelectedMarkerKey: (markerKey: string | null) => this.selectedMarkerKey.set(markerKey),
+      setSelectedMarkerKey: (markerKey: string | null) =>
+        this.state.setSelectedMarkerKey(markerKey),
       findReusableMarkerKey: (row, keys) =>
         this.mapMarkerReuseStrategyService.findReusableMarkerKey(
           this.map,
@@ -3376,7 +3257,7 @@ export class MapShellComponent implements OnDestroy {
       selectedKeysChanged = true;
     }
     if (selectedKeysChanged) {
-      this.selectedMarkerKeys.set(staleSelectedKeys);
+      this.state.setSelectedMarkerKeys(staleSelectedKeys);
     }
   }
 
@@ -3390,7 +3271,7 @@ export class MapShellComponent implements OnDestroy {
       corrected?: boolean;
       uploading?: boolean;
     }>,
-  ): L.DivIcon {
+  ): MapDivIcon {
     const markerState = this.uploadedPhotoMarkers.get(markerKey);
     const fallbackLabel =
       override?.fallbackLabel ??
@@ -3402,9 +3283,8 @@ export class MapShellComponent implements OnDestroy {
       fallbackLabel,
     );
 
-    return L.divIcon({
-      className: 'map-photo-marker-wrapper',
-      html: buildPhotoMarkerHtml({
+    return this.mapLeafletService.createPhotoMarkerIcon(
+      buildPhotoMarkerHtml({
         count: iconState.count,
         thumbnailUrl: iconState.thumbnailUrl,
         fallbackLabel: iconState.fallbackLabel,
@@ -3416,13 +3296,10 @@ export class MapShellComponent implements OnDestroy {
         loading: iconState.loading,
         zoomLevel: this.getPhotoMarkerZoomLevel(),
       }),
-      iconSize: PHOTO_MARKER_ICON_SIZE,
-      iconAnchor: PHOTO_MARKER_ICON_ANCHOR,
-      popupAnchor: PHOTO_MARKER_POPUP_ANCHOR,
-    });
+    );
   }
 
-  private handlePhotoMarkerClick(markerKey: string, clickEvent?: L.LeafletMouseEvent): void {
+  private handlePhotoMarkerClick(markerKey: string, clickEvent?: MapMouseEvent): void {
     const markerState = this.uploadedPhotoMarkers.get(markerKey);
     if (!markerState) {
       return;
@@ -3453,12 +3330,12 @@ export class MapShellComponent implements OnDestroy {
 
   private ensurePhotoPanelOpen(): void {
     if (!this.photoPanelOpen()) {
-      this.workspacePaneWidth.set(this.getWorkspacePaneOpeningWidth());
+      this.state.setWorkspacePaneWidth(this.getWorkspacePaneOpeningWidth());
     }
-    this.photoPanelOpen.set(true);
+    this.state.setPhotoPanelOpen(true);
   }
 
-  private isAdditiveMarkerSelection(clickEvent?: L.LeafletMouseEvent): boolean {
+  private isAdditiveMarkerSelection(clickEvent?: MapMouseEvent): boolean {
     return !!(clickEvent?.originalEvent.ctrlKey || clickEvent?.originalEvent.metaKey);
   }
 
@@ -3499,7 +3376,7 @@ export class MapShellComponent implements OnDestroy {
   /** Attach click + touch long-press interactions consistently for each new marker. */
   private attachMarkerInteractions(
     markerKey: string,
-    marker: L.Marker,
+    marker: MapMarker,
     options?: { fadeIn?: boolean },
   ): void {
     const shouldFadeIn = options?.fadeIn ?? true;
@@ -3519,13 +3396,13 @@ export class MapShellComponent implements OnDestroy {
   }
 
   /** Ensure marker click always resolves to the current marker key. */
-  private bindMarkerClickInteraction(markerKey: string, marker: L.Marker): void {
-    this.markerInteractionService.bindClick(marker, (event: L.LeafletMouseEvent) =>
+  private bindMarkerClickInteraction(markerKey: string, marker: MapMarker): void {
+    this.markerInteractionService.bindClick(marker, (event: MapMouseEvent) =>
       this.handlePhotoMarkerClick(markerKey, event),
     );
   }
 
-  private bindMarkerContextInteraction(markerKey: string, marker: L.Marker): void {
+  private bindMarkerContextInteraction(markerKey: string, marker: MapMarker): void {
     this.markerInteractionService.bindContextMenu(marker, {
       shouldBypass: () => this.consumeNativeContextMenuBypass(),
       onSecondaryReset: () => {
@@ -3546,7 +3423,7 @@ export class MapShellComponent implements OnDestroy {
     if (this.radiusSelectionService.hasCommittedSelection(this.radiusCommittedVisuals)) {
       const state = this.uploadedPhotoMarkers.get(markerKey);
       if (state) {
-        const markerLatLng = L.latLng(state.lat, state.lng);
+        const markerLatLng = this.mapLeafletService.createLatLng(state.lat, state.lng);
         const isInsideCommittedRadius = this.radiusSelectionService.isInsideAnyCommittedRadius(
           this.map,
           this.radiusCommittedVisuals,
@@ -3569,7 +3446,7 @@ export class MapShellComponent implements OnDestroy {
     this.openMarkerContextMenu(markerKey, event);
   }
 
-  private bindMarkerHoverInteraction(markerKey: string, marker: L.Marker): void {
+  private bindMarkerHoverInteraction(markerKey: string, marker: MapMarker): void {
     this.markerInteractionService.bindHover(marker, {
       onEnter: () => {
         this.setLinkedHoverMarkerFromMap(markerKey);
@@ -3580,7 +3457,7 @@ export class MapShellComponent implements OnDestroy {
           return;
         }
         this.setLinkedHoverMarkerFromMap(null);
-        this.linkedHoveredWorkspaceMediaIds.set(new Set());
+        this.state.setLinkedHoveredWorkspaceMediaIds(new Set());
       },
     });
   }
@@ -3613,7 +3490,7 @@ export class MapShellComponent implements OnDestroy {
    * Uses frame-based interpolation with easing so interrupted updates
    * can be retargeted cleanly without visual popping.
    */
-  private animateMarkerPosition(marker: L.Marker, lat: number, lng: number): void {
+  private animateMarkerPosition(marker: MapMarker, lat: number, lng: number): void {
     this.markerMotionService.animateMarkerPosition(
       marker,
       lat,
@@ -3623,7 +3500,7 @@ export class MapShellComponent implements OnDestroy {
     );
   }
 
-  private cancelMarkerMoveAnimation(marker: L.Marker): void {
+  private cancelMarkerMoveAnimation(marker: MapMarker): void {
     this.markerMotionService.cancelMarkerMoveAnimation(marker);
   }
 
@@ -3654,7 +3531,7 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    this.selectedMarkerKey.set(markerKey);
+    this.state.setSelectedMarkerKey(markerKey);
 
     if (previousMarkerKey) {
       this.refreshPhotoMarker(previousMarkerKey);
@@ -3672,7 +3549,7 @@ export class MapShellComponent implements OnDestroy {
       return;
     }
 
-    this.selectedMarkerKeys.set(nextKeys);
+    this.state.setSelectedMarkerKeys(nextKeys);
     this.markerSelectionSyncService.refreshChangedKeySet(previousKeys, nextKeys, (markerKey) =>
       this.refreshPhotoMarker(markerKey),
     );
@@ -3712,7 +3589,7 @@ export class MapShellComponent implements OnDestroy {
 
   private setLinkedHoveredWorkspaceImageIdsForMarker(markerKey: string | null): void {
     if (!markerKey) {
-      this.linkedHoveredWorkspaceMediaIds.set(new Set());
+      this.state.setLinkedHoveredWorkspaceMediaIds(new Set());
       return;
     }
 
@@ -3722,7 +3599,7 @@ export class MapShellComponent implements OnDestroy {
       this.workspaceViewService.rawImages(),
       (lat, lng) => this.toMarkerKey(lat, lng),
     );
-    this.linkedHoveredWorkspaceMediaIds.set(matchedIds);
+    this.state.setLinkedHoveredWorkspaceMediaIds(matchedIds);
   }
 
   private refreshActiveWorkspaceHoverLink(): void {
@@ -3811,7 +3688,7 @@ export class MapShellComponent implements OnDestroy {
 
   private isSingleMarkerInBounds(
     state: { count: number; lat: number; lng: number },
-    bounds: L.LatLngBounds,
+    bounds: MapLatLngBounds,
   ): boolean {
     return state.count === 1 && bounds.contains([state.lat, state.lng]);
   }
@@ -3955,7 +3832,7 @@ export class MapShellComponent implements OnDestroy {
   private renderPhotoMarker(
     markerKey: string,
     markerState: {
-      marker: L.Marker;
+      marker: MapMarker;
       count: number;
       thumbnailUrl?: string;
       thumbnailLoading?: boolean;
@@ -4025,24 +3902,24 @@ export class MapShellComponent implements OnDestroy {
     return 'far';
   }
 
-  private openMapContextMenuAt(latlng: L.LatLng, clientX: number, clientY: number): void {
+  private openMapContextMenuAt(latlng: MapLatLng, clientX: number, clientY: number): void {
     const position = this.mapContextActionsService.clampContextMenuPosition(clientX, clientY);
-    this.radiusContextMenuOpen.set(false);
-    this.markerContextMenuOpen.set(false);
-    this.mapContextMenuCoords.set({ lat: latlng.lat, lng: latlng.lng });
-    this.mapContextMenuPosition.set(position);
-    this.mapContextMenuOpen.set(true);
+    this.state.setRadiusContextMenuOpen(false);
+    this.state.setMarkerContextMenuOpen(false);
+    this.state.setMapContextMenuCoords({ lat: latlng.lat, lng: latlng.lng });
+    this.state.setMapContextMenuPosition(position);
+    this.state.setMapContextMenuOpen(true);
     this.focusFirstOpenMapMenuItem();
     this.suppressMapClickUntil = Date.now() + MapShellComponent.RADIUS_CLICK_GUARD_MS;
   }
 
-  private openRadiusContextMenuAt(latlng: L.LatLng, clientX: number, clientY: number): void {
+  private openRadiusContextMenuAt(latlng: MapLatLng, clientX: number, clientY: number): void {
     const position = this.mapContextActionsService.clampContextMenuPosition(clientX, clientY);
-    this.mapContextMenuOpen.set(false);
-    this.markerContextMenuOpen.set(false);
-    this.radiusContextMenuCoords.set({ lat: latlng.lat, lng: latlng.lng });
-    this.radiusContextMenuPosition.set(position);
-    this.radiusContextMenuOpen.set(true);
+    this.state.setMapContextMenuOpen(false);
+    this.state.setMarkerContextMenuOpen(false);
+    this.state.setRadiusContextMenuCoords({ lat: latlng.lat, lng: latlng.lng });
+    this.state.setRadiusContextMenuPosition(position);
+    this.state.setRadiusContextMenuOpen(true);
     this.focusFirstOpenMapMenuItem();
     this.suppressMapClickUntil = Date.now() + MapShellComponent.RADIUS_CLICK_GUARD_MS;
   }
@@ -4056,9 +3933,9 @@ export class MapShellComponent implements OnDestroy {
       this.map,
     );
 
-    this.mapContextMenuOpen.set(false);
-    this.radiusContextMenuOpen.set(false);
-    this.markerContextMenuPosition.set(position);
+    this.state.setMapContextMenuOpen(false);
+    this.state.setRadiusContextMenuOpen(false);
+    this.state.setMarkerContextMenuPosition(position);
     const selectedMarkerKeys = this.selectedMarkerKeys();
     const isMultiSelection = selectedMarkerKeys.size > 1 && selectedMarkerKeys.has(markerKey);
 
@@ -4077,7 +3954,7 @@ export class MapShellComponent implements OnDestroy {
 
       const combinedCount = multiStates.reduce((sum, marker) => sum + Math.max(1, marker.count), 0);
 
-      this.markerContextMenuPayload.set({
+      this.state.setMarkerContextMenuPayload({
         markerKey,
         count: combinedCount,
         lat: state.lat,
@@ -4086,7 +3963,7 @@ export class MapShellComponent implements OnDestroy {
         sourceCells: combinedSourceCells,
       });
     } else {
-      this.markerContextMenuPayload.set({
+      this.state.setMarkerContextMenuPayload({
         markerKey,
         count: state.count,
         lat: state.lat,
@@ -4097,7 +3974,7 @@ export class MapShellComponent implements OnDestroy {
       });
     }
 
-    this.markerContextMenuOpen.set(true);
+    this.state.setMarkerContextMenuOpen(true);
     this.focusFirstOpenMapMenuItem();
     this.suppressMapClickUntil = Date.now() + MapShellComponent.RADIUS_CLICK_GUARD_MS;
   }
@@ -4155,9 +4032,7 @@ export class MapShellComponent implements OnDestroy {
   }
 
   private async promptProjectSelection(): Promise<{ id: string; name: string } | null> {
-    const projects = await this.mapProjectActionsService.loadProjectOptions(
-      this.supabaseService.client,
-    );
+    const projects = await this.mapProjectActionsService.loadProjectOptions();
 
     if (!projects.ok) {
       this.toastService.show({
@@ -4174,6 +4049,21 @@ export class MapShellComponent implements OnDestroy {
       'Projekt auswaehlen',
       'Waehle ein bestehendes Projekt fuer die Zuweisung aus.',
     );
+  }
+
+  private getRemoveImagesFromProjectsFailureMessage(
+    result: RemoveImagesFromProjectsResult,
+  ): string {
+    switch (result.reason) {
+      case 'lookup-error':
+        return 'Projektzuordnungen konnten nicht geladen werden.';
+      case 'remove-error':
+        return 'Entfernen aus Projekten ist fehlgeschlagen.';
+      case 'empty':
+        return 'Keine Projektzuordnungen gefunden.';
+      default:
+        return 'Entfernen aus Projekten ist fehlgeschlagen.';
+    }
   }
 
   private async promptProjectNameFromRadius(): Promise<string | null> {

--- a/apps/web/src/app/features/map/map-shell/map-shell.state.ts
+++ b/apps/web/src/app/features/map/map-shell/map-shell.state.ts
@@ -3,21 +3,46 @@ import type { ProjectSelectOption } from '../../../shared/project-select-dialog/
 
 @Injectable()
 export class MapShellState {
-  readonly photoPanelOpen = signal(false);
-  readonly workspacePaneWidth = signal(360);
-  readonly selectedMarkerKey = signal<string | null>(null);
-  readonly selectedMarkerKeys = signal<Set<string>>(new Set());
-  readonly linkedHoveredWorkspaceMediaIds = signal<Set<string>>(new Set());
+  private readonly _photoPanelOpen = signal(false);
+  readonly photoPanelOpen = this._photoPanelOpen.asReadonly();
 
-  readonly mapContextMenuOpen = signal(false);
-  readonly mapContextMenuPosition = signal<{ x: number; y: number } | null>(null);
-  readonly mapContextMenuCoords = signal<{ lat: number; lng: number } | null>(null);
-  readonly radiusContextMenuOpen = signal(false);
-  readonly radiusContextMenuPosition = signal<{ x: number; y: number } | null>(null);
-  readonly radiusContextMenuCoords = signal<{ lat: number; lng: number } | null>(null);
-  readonly markerContextMenuOpen = signal(false);
-  readonly markerContextMenuPosition = signal<{ x: number; y: number } | null>(null);
-  readonly markerContextMenuPayload = signal<{
+  private readonly _workspacePaneWidth = signal(360);
+  readonly workspacePaneWidth = this._workspacePaneWidth.asReadonly();
+
+  private readonly _selectedMarkerKey = signal<string | null>(null);
+  readonly selectedMarkerKey = this._selectedMarkerKey.asReadonly();
+
+  private readonly _selectedMarkerKeys = signal<Set<string>>(new Set());
+  readonly selectedMarkerKeys = this._selectedMarkerKeys.asReadonly();
+
+  private readonly _linkedHoveredWorkspaceMediaIds = signal<Set<string>>(new Set());
+  readonly linkedHoveredWorkspaceMediaIds = this._linkedHoveredWorkspaceMediaIds.asReadonly();
+
+  private readonly _mapContextMenuOpen = signal(false);
+  readonly mapContextMenuOpen = this._mapContextMenuOpen.asReadonly();
+
+  private readonly _mapContextMenuPosition = signal<{ x: number; y: number } | null>(null);
+  readonly mapContextMenuPosition = this._mapContextMenuPosition.asReadonly();
+
+  private readonly _mapContextMenuCoords = signal<{ lat: number; lng: number } | null>(null);
+  readonly mapContextMenuCoords = this._mapContextMenuCoords.asReadonly();
+
+  private readonly _radiusContextMenuOpen = signal(false);
+  readonly radiusContextMenuOpen = this._radiusContextMenuOpen.asReadonly();
+
+  private readonly _radiusContextMenuPosition = signal<{ x: number; y: number } | null>(null);
+  readonly radiusContextMenuPosition = this._radiusContextMenuPosition.asReadonly();
+
+  private readonly _radiusContextMenuCoords = signal<{ lat: number; lng: number } | null>(null);
+  readonly radiusContextMenuCoords = this._radiusContextMenuCoords.asReadonly();
+
+  private readonly _markerContextMenuOpen = signal(false);
+  readonly markerContextMenuOpen = this._markerContextMenuOpen.asReadonly();
+
+  private readonly _markerContextMenuPosition = signal<{ x: number; y: number } | null>(null);
+  readonly markerContextMenuPosition = this._markerContextMenuPosition.asReadonly();
+
+  private readonly _markerContextMenuPayload = signal<{
     markerKey: string;
     count: number;
     lat: number;
@@ -26,29 +51,184 @@ export class MapShellState {
     isMultiSelection?: boolean;
     sourceCells: Array<{ lat: number; lng: number }>;
   } | null>(null);
+  readonly markerContextMenuPayload = this._markerContextMenuPayload.asReadonly();
 
-  readonly draftMediaMarker = signal<{ lat: number; lng: number; uploadCount: number } | null>(
-    null,
-  );
+  private readonly _draftMediaMarker = signal<{ lat: number; lng: number; uploadCount: number } | null>(null);
+  readonly draftMediaMarker = this._draftMediaMarker.asReadonly();
 
-  readonly projectSelectionDialogOpen = signal(false);
-  readonly projectSelectionDialogTitle = signal('Projekt auswaehlen');
-  readonly projectSelectionDialogMessage = signal('');
-  readonly projectSelectionDialogOptions = signal<ReadonlyArray<ProjectSelectOption>>([]);
-  readonly projectSelectionDialogSelectedId = signal<string | null>(null);
+  private readonly _projectSelectionDialogOpen = signal(false);
+  readonly projectSelectionDialogOpen = this._projectSelectionDialogOpen.asReadonly();
 
-  readonly projectNameDialogOpen = signal(false);
-  readonly projectNameDialogTitle = signal('Name fuer neues Projekt aus Radius');
-  readonly projectNameDialogMessage = signal('Gib einen Projektnamen ein.');
-  readonly projectNameDialogInitialValue = signal('');
+  private readonly _projectSelectionDialogTitle = signal('Projekt auswaehlen');
+  readonly projectSelectionDialogTitle = this._projectSelectionDialogTitle.asReadonly();
 
-  readonly batchAddressDialogOpen = signal(false);
-  readonly batchAddressDialogTitle = signal('Adresse fuer Auswahl aendern');
-  readonly batchAddressDialogMessage = signal('Adresse fuer alle ausgewaehlten Medien anwenden.');
-  readonly batchAddressTargetMediaIds = signal<ReadonlyArray<string>>([]);
+  private readonly _projectSelectionDialogMessage = signal('');
+  readonly projectSelectionDialogMessage = this._projectSelectionDialogMessage.asReadonly();
 
-  readonly detailMediaId = signal<string | null>(null);
+  private readonly _projectSelectionDialogOptions = signal<ReadonlyArray<ProjectSelectOption>>([]);
+  readonly projectSelectionDialogOptions = this._projectSelectionDialogOptions.asReadonly();
+
+  private readonly _projectSelectionDialogSelectedId = signal<string | null>(null);
+  readonly projectSelectionDialogSelectedId = this._projectSelectionDialogSelectedId.asReadonly();
+
+  private readonly _projectNameDialogOpen = signal(false);
+  readonly projectNameDialogOpen = this._projectNameDialogOpen.asReadonly();
+
+  private readonly _projectNameDialogTitle = signal('Name fuer neues Projekt aus Radius');
+  readonly projectNameDialogTitle = this._projectNameDialogTitle.asReadonly();
+
+  private readonly _projectNameDialogMessage = signal('Gib einen Projektnamen ein.');
+  readonly projectNameDialogMessage = this._projectNameDialogMessage.asReadonly();
+
+  private readonly _projectNameDialogInitialValue = signal('');
+  readonly projectNameDialogInitialValue = this._projectNameDialogInitialValue.asReadonly();
+
+  private readonly _batchAddressDialogOpen = signal(false);
+  readonly batchAddressDialogOpen = this._batchAddressDialogOpen.asReadonly();
+
+  private readonly _batchAddressDialogTitle = signal('Adresse fuer Auswahl aendern');
+  readonly batchAddressDialogTitle = this._batchAddressDialogTitle.asReadonly();
+
+  private readonly _batchAddressDialogMessage = signal('Adresse fuer alle ausgewaehlten Medien anwenden.');
+  readonly batchAddressDialogMessage = this._batchAddressDialogMessage.asReadonly();
+
+  private readonly _batchAddressTargetMediaIds = signal<ReadonlyArray<string>>([]);
+  readonly batchAddressTargetMediaIds = this._batchAddressTargetMediaIds.asReadonly();
+
+  private readonly _detailMediaId = signal<string | null>(null);
+  readonly detailMediaId = this._detailMediaId.asReadonly();
 
   /** Detail view address-search handoff (map shell consumes in media detail flow). */
-  readonly detailAddressSearchRequest = signal<{ mediaId: string; requestId: number } | null>(null);
+  private readonly _detailAddressSearchRequest = signal<{ mediaId: string; requestId: number } | null>(null);
+  readonly detailAddressSearchRequest = this._detailAddressSearchRequest.asReadonly();
+
+  setPhotoPanelOpen(value: boolean): void {
+    this._photoPanelOpen.set(value);
+  }
+
+  setWorkspacePaneWidth(value: number): void {
+    this._workspacePaneWidth.set(value);
+  }
+
+  setSelectedMarkerKey(value: string | null): void {
+    this._selectedMarkerKey.set(value);
+  }
+
+  setSelectedMarkerKeys(value: Set<string>): void {
+    this._selectedMarkerKeys.set(value);
+  }
+
+  setLinkedHoveredWorkspaceMediaIds(value: Set<string>): void {
+    this._linkedHoveredWorkspaceMediaIds.set(value);
+  }
+
+  setMapContextMenuOpen(value: boolean): void {
+    this._mapContextMenuOpen.set(value);
+  }
+
+  setMapContextMenuPosition(value: { x: number; y: number } | null): void {
+    this._mapContextMenuPosition.set(value);
+  }
+
+  setMapContextMenuCoords(value: { lat: number; lng: number } | null): void {
+    this._mapContextMenuCoords.set(value);
+  }
+
+  setRadiusContextMenuOpen(value: boolean): void {
+    this._radiusContextMenuOpen.set(value);
+  }
+
+  setRadiusContextMenuPosition(value: { x: number; y: number } | null): void {
+    this._radiusContextMenuPosition.set(value);
+  }
+
+  setRadiusContextMenuCoords(value: { lat: number; lng: number } | null): void {
+    this._radiusContextMenuCoords.set(value);
+  }
+
+  setMarkerContextMenuOpen(value: boolean): void {
+    this._markerContextMenuOpen.set(value);
+  }
+
+  setMarkerContextMenuPosition(value: { x: number; y: number } | null): void {
+    this._markerContextMenuPosition.set(value);
+  }
+
+  setMarkerContextMenuPayload(
+    value: {
+      markerKey: string;
+      count: number;
+      lat: number;
+      lng: number;
+      mediaId?: string;
+      isMultiSelection?: boolean;
+      sourceCells: Array<{ lat: number; lng: number }>;
+    } | null,
+  ): void {
+    this._markerContextMenuPayload.set(value);
+  }
+
+  setDraftMediaMarker(value: { lat: number; lng: number; uploadCount: number } | null): void {
+    this._draftMediaMarker.set(value);
+  }
+
+  setProjectSelectionDialogOpen(value: boolean): void {
+    this._projectSelectionDialogOpen.set(value);
+  }
+
+  setProjectSelectionDialogTitle(value: string): void {
+    this._projectSelectionDialogTitle.set(value);
+  }
+
+  setProjectSelectionDialogMessage(value: string): void {
+    this._projectSelectionDialogMessage.set(value);
+  }
+
+  setProjectSelectionDialogOptions(value: ReadonlyArray<ProjectSelectOption>): void {
+    this._projectSelectionDialogOptions.set(value);
+  }
+
+  setProjectSelectionDialogSelectedId(value: string | null): void {
+    this._projectSelectionDialogSelectedId.set(value);
+  }
+
+  setProjectNameDialogOpen(value: boolean): void {
+    this._projectNameDialogOpen.set(value);
+  }
+
+  setProjectNameDialogTitle(value: string): void {
+    this._projectNameDialogTitle.set(value);
+  }
+
+  setProjectNameDialogMessage(value: string): void {
+    this._projectNameDialogMessage.set(value);
+  }
+
+  setProjectNameDialogInitialValue(value: string): void {
+    this._projectNameDialogInitialValue.set(value);
+  }
+
+  setBatchAddressDialogOpen(value: boolean): void {
+    this._batchAddressDialogOpen.set(value);
+  }
+
+  setBatchAddressDialogTitle(value: string): void {
+    this._batchAddressDialogTitle.set(value);
+  }
+
+  setBatchAddressDialogMessage(value: string): void {
+    this._batchAddressDialogMessage.set(value);
+  }
+
+  setBatchAddressTargetMediaIds(value: ReadonlyArray<string>): void {
+    this._batchAddressTargetMediaIds.set(value);
+  }
+
+  setDetailMediaId(value: string | null): void {
+    this._detailMediaId.set(value);
+  }
+
+  setDetailAddressSearchRequest(value: { mediaId: string; requestId: number } | null): void {
+    this._detailAddressSearchRequest.set(value);
+  }
 }

--- a/apps/web/src/app/features/map/map-shell/marker-context-photo-delete.service.ts
+++ b/apps/web/src/app/features/map/map-shell/marker-context-photo-delete.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { inject, Injectable } from '@angular/core';
+import { SupabaseService } from '../../../core/supabase/supabase.service';
 
 export interface DeleteImageByIdResult {
   ok: boolean;
@@ -14,6 +14,8 @@ export interface SingleMarkerContextPayload {
 
 @Injectable({ providedIn: 'root' })
 export class MarkerContextPhotoDeleteService {
+  private readonly supabaseService = inject(SupabaseService);
+
   getSingleImageTarget(
     payload: SingleMarkerContextPayload | null,
   ): { markerKey: string; mediaId: string } | null {
@@ -41,8 +43,8 @@ export class MarkerContextPhotoDeleteService {
     );
   }
 
-  async deleteImageById(client: SupabaseClient, mediaId: string): Promise<DeleteImageByIdResult> {
-    const { error } = await client
+  async deleteImageById(mediaId: string): Promise<DeleteImageByIdResult> {
+    const { error } = await this.supabaseService.client
       .from('media_items')
       .delete()
       .or(`id.eq.${mediaId},source_image_id.eq.${mediaId}`);

--- a/apps/web/src/app/features/map/map-shell/viewport-marker-query.service.ts
+++ b/apps/web/src/app/features/map/map-shell/viewport-marker-query.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import type * as L from 'leaflet';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseService } from '../../../core/supabase/supabase.service';
 
 export interface ViewportMarkerQueryResult<T> {
   data: T[] | null;
@@ -15,8 +15,9 @@ export interface ViewportMarkerQueryResult<T> {
 
 @Injectable({ providedIn: 'root' })
 export class ViewportMarkerQueryService {
+  private readonly supabaseService = inject(SupabaseService);
+
   async fetchViewportMarkers<T>(
-    client: SupabaseClient,
     map: L.Map,
     signal: AbortSignal,
   ): Promise<ViewportMarkerQueryResult<T>> {
@@ -33,7 +34,7 @@ export class ViewportMarkerQueryService {
     const fetchEast = bounds.getEast() + lngPad;
     const roundedZoom = Math.round(zoom);
 
-    const { data, error } = await client
+    const { data, error } = await this.supabaseService.client
       .rpc('viewport_markers', {
         min_lat: fetchSouth,
         min_lng: fetchWest,

--- a/apps/web/src/app/features/upload/upload-panel-dialog-actions.service.ts
+++ b/apps/web/src/app/features/upload/upload-panel-dialog-actions.service.ts
@@ -67,6 +67,10 @@ export class UploadPanelDialogActionsService {
   private readonly t = (key: string, fallback = ''): string => this.i18nService.t(key, fallback);
 
   private options: UploadPanelDialogActionsRegisterOptions | null = null;
+  private readonly projectNameDialogOpen = signal(false);
+  private readonly projectNameDialogTitle = signal('');
+  private readonly projectNameDialogMessage = signal('');
+  private readonly projectNameDialogInitialValue = signal('');
 
   private readonly projectDialogSignals = {
     projectSelectionDialogOpen: this.dialogSignals.projectSelectionDialogOpen,
@@ -74,10 +78,25 @@ export class UploadPanelDialogActionsService {
     projectSelectionDialogMessage: this.dialogSignals.projectSelectionDialogMessage,
     projectSelectionDialogOptions: this.dialogSignals.projectSelectionDialogOptions,
     projectSelectionDialogSelectedId: this.dialogSignals.projectSelectionDialogSelectedId,
-    projectNameDialogOpen: signal(false),
-    projectNameDialogTitle: signal(''),
-    projectNameDialogMessage: signal(''),
-    projectNameDialogInitialValue: signal(''),
+    projectNameDialogOpen: this.projectNameDialogOpen.asReadonly(),
+    projectNameDialogTitle: this.projectNameDialogTitle.asReadonly(),
+    projectNameDialogMessage: this.projectNameDialogMessage.asReadonly(),
+    projectNameDialogInitialValue: this.projectNameDialogInitialValue.asReadonly(),
+    setProjectSelectionDialogOpen: (value: boolean) =>
+      this.dialogSignals.setProjectSelectionDialogOpen(value),
+    setProjectSelectionDialogTitle: (value: string) =>
+      this.dialogSignals.setProjectSelectionDialogTitle(value),
+    setProjectSelectionDialogMessage: (value: string) =>
+      this.dialogSignals.setProjectSelectionDialogMessage(value),
+    setProjectSelectionDialogOptions: (value: ReadonlyArray<{ id: string; name: string }>) =>
+      this.dialogSignals.setProjectSelectionDialogOptions(value),
+    setProjectSelectionDialogSelectedId: (value: string | null) =>
+      this.dialogSignals.setProjectSelectionDialogSelectedId(value),
+    setProjectNameDialogOpen: (value: boolean) => this.projectNameDialogOpen.set(value),
+    setProjectNameDialogTitle: (value: string) => this.projectNameDialogTitle.set(value),
+    setProjectNameDialogMessage: (value: string) => this.projectNameDialogMessage.set(value),
+    setProjectNameDialogInitialValue: (value: string) =>
+      this.projectNameDialogInitialValue.set(value),
   };
 
   register(options: UploadPanelDialogActionsRegisterOptions): void {
@@ -92,7 +111,7 @@ export class UploadPanelDialogActionsService {
   }
 
   onLocationAddressDialogQueryInput(query: string): void {
-    this.dialogSignals.locationAddressDialogQuery.set(query);
+    this.dialogSignals.setLocationAddressDialogQuery(query);
     const timeout = this.dialogSignals.getLocationAddressSearchTimeout();
     if (timeout) {
       clearTimeout(timeout);
@@ -100,8 +119,8 @@ export class UploadPanelDialogActionsService {
     }
 
     if (!query.trim()) {
-      this.dialogSignals.locationAddressDialogLoading.set(false);
-      this.dialogSignals.locationAddressDialogSuggestions.set([]);
+      this.dialogSignals.setLocationAddressDialogLoading(false);
+      this.dialogSignals.setLocationAddressDialogSuggestions([]);
       this.ctx.locationPreviewCleared();
       return;
     }
@@ -113,10 +132,10 @@ export class UploadPanelDialogActionsService {
   }
 
   onLocationAddressDialogClose(): void {
-    this.dialogSignals.locationAddressDialogOpen.set(false);
-    this.dialogSignals.locationAddressDialogQuery.set('');
-    this.dialogSignals.locationAddressDialogSuggestions.set([]);
-    this.dialogSignals.pendingLocationAddressJob.set(null);
+    this.dialogSignals.setLocationAddressDialogOpen(false);
+    this.dialogSignals.setLocationAddressDialogQuery('');
+    this.dialogSignals.setLocationAddressDialogSuggestions([]);
+    this.dialogSignals.setPendingLocationAddressJob(null);
     this.ctx.locationPreviewCleared();
   }
 
@@ -238,7 +257,7 @@ export class UploadPanelDialogActionsService {
     this.mapProjectDialogService.confirmProjectSelection(this.projectDialogSignals, projectId);
 
     if (!job || !selected) {
-      this.dialogSignals.pendingProjectAssignmentJob.set(null);
+      this.dialogSignals.setPendingProjectAssignmentJob(null);
       return;
     }
 
@@ -249,13 +268,13 @@ export class UploadPanelDialogActionsService {
         type: 'success',
         dedupe: true,
       });
-      this.dialogSignals.pendingProjectAssignmentJob.set(null);
+      this.dialogSignals.setPendingProjectAssignmentJob(null);
       this.ctx.setLane('uploading');
       return;
     }
 
     if (!job.imageId) {
-      this.dialogSignals.pendingProjectAssignmentJob.set(null);
+      this.dialogSignals.setPendingProjectAssignmentJob(null);
       return;
     }
 
@@ -277,12 +296,12 @@ export class UploadPanelDialogActionsService {
       });
     }
 
-    this.dialogSignals.pendingProjectAssignmentJob.set(null);
+    this.dialogSignals.setPendingProjectAssignmentJob(null);
   }
 
   onProjectSelectionDialogCancelled(): void {
     this.mapProjectDialogService.cancelProjectSelection(this.projectDialogSignals);
-    this.dialogSignals.pendingProjectAssignmentJob.set(null);
+    this.dialogSignals.setPendingProjectAssignmentJob(null);
   }
 
   onDuplicateResolutionApplyToBatchChange(event: Event): void {
@@ -290,7 +309,7 @@ export class UploadPanelDialogActionsService {
     if (!(target instanceof HTMLInputElement)) {
       return;
     }
-    this.dialogSignals.duplicateResolutionApplyToBatch.set(target.checked);
+    this.dialogSignals.setDuplicateResolutionApplyToBatch(target.checked);
   }
 
   async onDuplicateResolutionChoice(choice: DuplicateResolutionChoice): Promise<void> {
@@ -346,7 +365,7 @@ export class UploadPanelDialogActionsService {
       return;
     }
 
-    this.dialogSignals.pendingProjectAssignmentJob.set(job);
+    this.dialogSignals.setPendingProjectAssignmentJob(job);
     const prioritizedOptions = this.prioritizeBoundProjectOptions(job, optionsResult.options);
     void this.mapProjectDialogService.openProjectSelectionDialog(
       this.projectDialogSignals,
@@ -357,15 +376,15 @@ export class UploadPanelDialogActionsService {
   }
 
   openDuplicateResolutionDialog(job: UploadJob): void {
-    this.dialogSignals.pendingDuplicateResolutionJob.set(job);
-    this.dialogSignals.duplicateResolutionApplyToBatch.set(false);
-    this.dialogSignals.duplicateResolutionDialogOpen.set(true);
+    this.dialogSignals.setPendingDuplicateResolutionJob(job);
+    this.dialogSignals.setDuplicateResolutionApplyToBatch(false);
+    this.dialogSignals.setDuplicateResolutionDialogOpen(true);
   }
 
   closeDuplicateResolutionDialog(): void {
-    this.dialogSignals.pendingDuplicateResolutionJob.set(null);
-    this.dialogSignals.duplicateResolutionApplyToBatch.set(false);
-    this.dialogSignals.duplicateResolutionDialogOpen.set(false);
+    this.dialogSignals.setPendingDuplicateResolutionJob(null);
+    this.dialogSignals.setDuplicateResolutionApplyToBatch(false);
+    this.dialogSignals.setDuplicateResolutionDialogOpen(false);
   }
 
   openLocationAddressDialog(job: UploadJob): void {
@@ -373,25 +392,25 @@ export class UploadPanelDialogActionsService {
       return;
     }
 
-    this.dialogSignals.pendingLocationAddressJob.set(job);
-    this.dialogSignals.locationAddressDialogQuery.set('');
-    this.dialogSignals.locationAddressDialogSuggestions.set([]);
-    this.dialogSignals.locationAddressDialogLoading.set(false);
-    this.dialogSignals.locationAddressDialogOpen.set(true);
+    this.dialogSignals.setPendingLocationAddressJob(job);
+    this.dialogSignals.setLocationAddressDialogQuery('');
+    this.dialogSignals.setLocationAddressDialogSuggestions([]);
+    this.dialogSignals.setLocationAddressDialogLoading(false);
+    this.dialogSignals.setLocationAddressDialogOpen(true);
   }
 
   private async searchLocationAddress(query: string): Promise<void> {
     const normalized = query.trim();
     if (!normalized) {
-      this.dialogSignals.locationAddressDialogSuggestions.set([]);
-      this.dialogSignals.locationAddressDialogLoading.set(false);
+      this.dialogSignals.setLocationAddressDialogSuggestions([]);
+      this.dialogSignals.setLocationAddressDialogLoading(false);
       return;
     }
 
-    this.dialogSignals.locationAddressDialogLoading.set(true);
+    this.dialogSignals.setLocationAddressDialogLoading(true);
     const results = await this.geocodingService.search(normalized, { limit: 6 });
-    this.dialogSignals.locationAddressDialogLoading.set(false);
-    this.dialogSignals.locationAddressDialogSuggestions.set(
+    this.dialogSignals.setLocationAddressDialogLoading(false);
+    this.dialogSignals.setLocationAddressDialogSuggestions(
       mapSearchResultsToForwardSuggestions(results),
     );
   }

--- a/apps/web/src/app/features/upload/upload-panel-dialog-handlers.service.ts
+++ b/apps/web/src/app/features/upload/upload-panel-dialog-handlers.service.ts
@@ -13,7 +13,7 @@
  *  - All search timeouts and state cleanup
  */
 
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, inject, signal, type Signal } from '@angular/core';
 import type { UploadJob } from '../../core/upload/upload-manager.service';
 import { GeocodingService } from '../../core/geocoding/geocoding.service';
 import { ToastService } from '../../core/toast/toast.service';
@@ -28,15 +28,16 @@ import type { ProjectSelectOption } from '../../shared/project-select-dialog/pro
 import type { GeocoderSearchResult } from '../../core/geocoding/geocoding.service';
 
 export interface DialogSignals {
-  projectSelectionDialogOpen: ReturnType<typeof signal<boolean>>;
-  projectSelectionDialogTitle: ReturnType<typeof signal<string>>;
-  projectSelectionDialogMessage: ReturnType<typeof signal<string>>;
-  projectSelectionDialogOptions: ReturnType<typeof signal<ReadonlyArray<ProjectSelectOption>>>;
-  projectSelectionDialogSelectedId: ReturnType<typeof signal<string | null>>;
-  projectNameDialogOpen: ReturnType<typeof signal<boolean>>;
-  projectNameDialogTitle: ReturnType<typeof signal<string>>;
-  projectNameDialogMessage: ReturnType<typeof signal<string>>;
-  projectNameDialogInitialValue: ReturnType<typeof signal<string>>;
+  projectSelectionDialogOptions: Signal<ReadonlyArray<ProjectSelectOption>>;
+  setProjectSelectionDialogOpen(value: boolean): void;
+  setProjectSelectionDialogTitle(value: string): void;
+  setProjectSelectionDialogMessage(value: string): void;
+  setProjectSelectionDialogOptions(value: ReadonlyArray<ProjectSelectOption>): void;
+  setProjectSelectionDialogSelectedId(value: string | null): void;
+  setProjectNameDialogOpen(value: boolean): void;
+  setProjectNameDialogTitle(value: string): void;
+  setProjectNameDialogMessage(value: string): void;
+  setProjectNameDialogInitialValue(value: string): void;
 }
 
 @Injectable()
@@ -54,28 +55,52 @@ export class UploadPanelDialogHandlersService {
 
   private locationAddressSearchTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  readonly locationAddressDialogQuery = signal('');
-  readonly locationAddressDialogLoading = signal(false);
-  readonly locationAddressDialogSuggestions = signal<ForwardGeocodeResult[]>([]);
-  readonly locationAddressDialogOpen = signal(false);
+  private readonly _locationAddressDialogQuery = signal('');
+  readonly locationAddressDialogQuery = this._locationAddressDialogQuery.asReadonly();
 
-  readonly projectSelectionDialogOpen = signal(false);
-  readonly projectSelectionDialogTitle = signal(
+  private readonly _locationAddressDialogLoading = signal(false);
+  readonly locationAddressDialogLoading = this._locationAddressDialogLoading.asReadonly();
+
+  private readonly _locationAddressDialogSuggestions = signal<ForwardGeocodeResult[]>([]);
+  readonly locationAddressDialogSuggestions = this._locationAddressDialogSuggestions.asReadonly();
+
+  private readonly _locationAddressDialogOpen = signal(false);
+  readonly locationAddressDialogOpen = this._locationAddressDialogOpen.asReadonly();
+
+  private readonly _projectSelectionDialogOpen = signal(false);
+  readonly projectSelectionDialogOpen = this._projectSelectionDialogOpen.asReadonly();
+
+  private readonly _projectSelectionDialogTitle = signal(
     this.t('upload.item.menu.assignProject', 'Assign project'),
   );
-  readonly projectSelectionDialogMessage = signal('');
-  readonly projectSelectionDialogOptions = signal<ReadonlyArray<ProjectSelectOption>>([]);
-  readonly projectSelectionDialogSelectedId = signal<string | null>(null);
+  readonly projectSelectionDialogTitle = this._projectSelectionDialogTitle.asReadonly();
 
-  readonly projectNameDialogOpen = signal(false);
-  readonly projectNameDialogTitle = signal('');
-  readonly projectNameDialogMessage = signal('');
-  readonly projectNameDialogInitialValue = signal('');
+  private readonly _projectSelectionDialogMessage = signal('');
+  readonly projectSelectionDialogMessage = this._projectSelectionDialogMessage.asReadonly();
 
-  readonly duplicateResolutionDialogOpen = signal(false);
-  readonly duplicateResolutionApplyToBatch = signal(false);
+  private readonly _projectSelectionDialogOptions = signal<ReadonlyArray<ProjectSelectOption>>([]);
+  readonly projectSelectionDialogOptions = this._projectSelectionDialogOptions.asReadonly();
 
-  constructor() {}
+  private readonly _projectSelectionDialogSelectedId = signal<string | null>(null);
+  readonly projectSelectionDialogSelectedId = this._projectSelectionDialogSelectedId.asReadonly();
+
+  private readonly _projectNameDialogOpen = signal(false);
+  readonly projectNameDialogOpen = this._projectNameDialogOpen.asReadonly();
+
+  private readonly _projectNameDialogTitle = signal('');
+  readonly projectNameDialogTitle = this._projectNameDialogTitle.asReadonly();
+
+  private readonly _projectNameDialogMessage = signal('');
+  readonly projectNameDialogMessage = this._projectNameDialogMessage.asReadonly();
+
+  private readonly _projectNameDialogInitialValue = signal('');
+  readonly projectNameDialogInitialValue = this._projectNameDialogInitialValue.asReadonly();
+
+  private readonly _duplicateResolutionDialogOpen = signal(false);
+  readonly duplicateResolutionDialogOpen = this._duplicateResolutionDialogOpen.asReadonly();
+
+  private readonly _duplicateResolutionApplyToBatch = signal(false);
+  readonly duplicateResolutionApplyToBatch = this._duplicateResolutionApplyToBatch.asReadonly();
 
   // ── Location Address Dialog ────────────────────────────────────────────
 
@@ -86,16 +111,16 @@ export class UploadPanelDialogHandlersService {
       return;
     }
 
-    this.locationAddressDialogQuery.set('');
-    this.locationAddressDialogSuggestions.set([]);
-    this.locationAddressDialogLoading.set(false);
-    this.locationAddressDialogOpen.set(true);
+    this._locationAddressDialogQuery.set('');
+    this._locationAddressDialogSuggestions.set([]);
+    this._locationAddressDialogLoading.set(false);
+    this._locationAddressDialogOpen.set(true);
   }
 
   closeLocationAddressDialog(): void {
-    this.locationAddressDialogOpen.set(false);
-    this.locationAddressDialogQuery.set('');
-    this.locationAddressDialogSuggestions.set([]);
+    this._locationAddressDialogOpen.set(false);
+    this._locationAddressDialogQuery.set('');
+    this._locationAddressDialogSuggestions.set([]);
     if (this.locationAddressSearchTimeout) {
       clearTimeout(this.locationAddressSearchTimeout);
       this.locationAddressSearchTimeout = null;
@@ -103,15 +128,15 @@ export class UploadPanelDialogHandlersService {
   }
 
   onLocationAddressDialogQueryInput(query: string): void {
-    this.locationAddressDialogQuery.set(query);
+    this._locationAddressDialogQuery.set(query);
     if (this.locationAddressSearchTimeout) {
       clearTimeout(this.locationAddressSearchTimeout);
       this.locationAddressSearchTimeout = null;
     }
 
     if (!query.trim()) {
-      this.locationAddressDialogSuggestions.set([]);
-      this.locationAddressDialogLoading.set(false);
+      this._locationAddressDialogSuggestions.set([]);
+      this._locationAddressDialogLoading.set(false);
       return;
     }
 
@@ -154,14 +179,14 @@ export class UploadPanelDialogHandlersService {
   private async searchLocationAddress(query: string): Promise<void> {
     const normalized = query.trim();
     if (!normalized) {
-      this.locationAddressDialogSuggestions.set([]);
+      this._locationAddressDialogSuggestions.set([]);
       return;
     }
 
-    this.locationAddressDialogLoading.set(true);
+    this._locationAddressDialogLoading.set(true);
     const results = await this.geocodingService.search(normalized, { limit: 6 });
-    this.locationAddressDialogLoading.set(false);
-    this.locationAddressDialogSuggestions.set(this.mapSearchResultsToForwardSuggestions(results));
+    this._locationAddressDialogLoading.set(false);
+    this._locationAddressDialogSuggestions.set(this.mapSearchResultsToForwardSuggestions(results));
   }
 
   private mapSearchResultsToForwardSuggestions(
@@ -234,13 +259,13 @@ export class UploadPanelDialogHandlersService {
   // ── Duplicate Resolution Dialog ────────────────────────────────────────
 
   openDuplicateResolutionDialog(): void {
-    this.duplicateResolutionApplyToBatch.set(false);
-    this.duplicateResolutionDialogOpen.set(true);
+    this._duplicateResolutionApplyToBatch.set(false);
+    this._duplicateResolutionDialogOpen.set(true);
   }
 
   closeDuplicateResolutionDialog(): void {
-    this.duplicateResolutionApplyToBatch.set(false);
-    this.duplicateResolutionDialogOpen.set(false);
+    this._duplicateResolutionApplyToBatch.set(false);
+    this._duplicateResolutionDialogOpen.set(false);
   }
 
   onDuplicateResolutionApplyToBatchChange(event: Event): void {
@@ -248,6 +273,42 @@ export class UploadPanelDialogHandlersService {
     if (!(target instanceof HTMLInputElement)) {
       return;
     }
-    this.duplicateResolutionApplyToBatch.set(target.checked);
+    this._duplicateResolutionApplyToBatch.set(target.checked);
+  }
+
+  setProjectSelectionDialogOpen(value: boolean): void {
+    this._projectSelectionDialogOpen.set(value);
+  }
+
+  setProjectSelectionDialogTitle(value: string): void {
+    this._projectSelectionDialogTitle.set(value);
+  }
+
+  setProjectSelectionDialogMessage(value: string): void {
+    this._projectSelectionDialogMessage.set(value);
+  }
+
+  setProjectSelectionDialogOptions(value: ReadonlyArray<ProjectSelectOption>): void {
+    this._projectSelectionDialogOptions.set(value);
+  }
+
+  setProjectSelectionDialogSelectedId(value: string | null): void {
+    this._projectSelectionDialogSelectedId.set(value);
+  }
+
+  setProjectNameDialogOpen(value: boolean): void {
+    this._projectNameDialogOpen.set(value);
+  }
+
+  setProjectNameDialogTitle(value: string): void {
+    this._projectNameDialogTitle.set(value);
+  }
+
+  setProjectNameDialogMessage(value: string): void {
+    this._projectNameDialogMessage.set(value);
+  }
+
+  setProjectNameDialogInitialValue(value: string): void {
+    this._projectNameDialogInitialValue.set(value);
   }
 }

--- a/apps/web/src/app/features/upload/upload-panel-dialog-signals.service.ts
+++ b/apps/web/src/app/features/upload/upload-panel-dialog-signals.service.ts
@@ -14,52 +14,86 @@ import type { UploadJob } from '../../core/upload/upload-manager.service';
 export class UploadPanelDialogSignals {
   // ── Location Address Dialog ────────────────────────────────────────────
 
-  readonly locationAddressDialogOpen = signal(false);
-  readonly locationAddressDialogQuery = signal('');
-  readonly locationAddressDialogLoading = signal(false);
-  readonly locationAddressDialogSuggestions = signal<ForwardGeocodeResult[]>([]);
-  readonly pendingLocationAddressJob = signal<UploadJob | null>(null);
+  private readonly _locationAddressDialogOpen = signal(false);
+  readonly locationAddressDialogOpen = this._locationAddressDialogOpen.asReadonly();
+
+  private readonly _locationAddressDialogQuery = signal('');
+  readonly locationAddressDialogQuery = this._locationAddressDialogQuery.asReadonly();
+
+  private readonly _locationAddressDialogLoading = signal(false);
+  readonly locationAddressDialogLoading = this._locationAddressDialogLoading.asReadonly();
+
+  private readonly _locationAddressDialogSuggestions = signal<ForwardGeocodeResult[]>([]);
+  readonly locationAddressDialogSuggestions = this._locationAddressDialogSuggestions.asReadonly();
+
+  private readonly _pendingLocationAddressJob = signal<UploadJob | null>(null);
+  readonly pendingLocationAddressJob = this._pendingLocationAddressJob.asReadonly();
+
   private locationAddressSearchTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // ── Project Selection Dialog ───────────────────────────────────────────
 
-  readonly projectSelectionDialogOpen = signal(false);
-  readonly projectSelectionDialogTitle = signal('');
-  readonly projectSelectionDialogMessage = signal('');
-  readonly projectSelectionDialogOptions = signal<ReadonlyArray<ProjectSelectOption>>([]);
-  readonly projectSelectionDialogSelectedId = signal<string | null>(null);
-  readonly pendingProjectAssignmentJob = signal<UploadJob | null>(null);
-  readonly projectNameDialogOpen = signal(false);
-  readonly projectNameDialogTitle = signal('');
-  readonly projectNameDialogMessage = signal('');
-  readonly projectNameDialogInitialValue = signal('');
+  private readonly _projectSelectionDialogOpen = signal(false);
+  readonly projectSelectionDialogOpen = this._projectSelectionDialogOpen.asReadonly();
+
+  private readonly _projectSelectionDialogTitle = signal('');
+  readonly projectSelectionDialogTitle = this._projectSelectionDialogTitle.asReadonly();
+
+  private readonly _projectSelectionDialogMessage = signal('');
+  readonly projectSelectionDialogMessage = this._projectSelectionDialogMessage.asReadonly();
+
+  private readonly _projectSelectionDialogOptions = signal<ReadonlyArray<ProjectSelectOption>>([]);
+  readonly projectSelectionDialogOptions = this._projectSelectionDialogOptions.asReadonly();
+
+  private readonly _projectSelectionDialogSelectedId = signal<string | null>(null);
+  readonly projectSelectionDialogSelectedId = this._projectSelectionDialogSelectedId.asReadonly();
+
+  private readonly _pendingProjectAssignmentJob = signal<UploadJob | null>(null);
+  readonly pendingProjectAssignmentJob = this._pendingProjectAssignmentJob.asReadonly();
+
+  private readonly _projectNameDialogOpen = signal(false);
+  readonly projectNameDialogOpen = this._projectNameDialogOpen.asReadonly();
+
+  private readonly _projectNameDialogTitle = signal('');
+  readonly projectNameDialogTitle = this._projectNameDialogTitle.asReadonly();
+
+  private readonly _projectNameDialogMessage = signal('');
+  readonly projectNameDialogMessage = this._projectNameDialogMessage.asReadonly();
+
+  private readonly _projectNameDialogInitialValue = signal('');
+  readonly projectNameDialogInitialValue = this._projectNameDialogInitialValue.asReadonly();
 
   // ── Duplicate Resolution Dialog ────────────────────────────────────────
 
-  readonly duplicateResolutionDialogOpen = signal(false);
-  readonly duplicateResolutionApplyToBatch = signal(false);
-  readonly pendingDuplicateResolutionJob = signal<UploadJob | null>(null);
+  private readonly _duplicateResolutionDialogOpen = signal(false);
+  readonly duplicateResolutionDialogOpen = this._duplicateResolutionDialogOpen.asReadonly();
+
+  private readonly _duplicateResolutionApplyToBatch = signal(false);
+  readonly duplicateResolutionApplyToBatch = this._duplicateResolutionApplyToBatch.asReadonly();
+
+  private readonly _pendingDuplicateResolutionJob = signal<UploadJob | null>(null);
+  readonly pendingDuplicateResolutionJob = this._pendingDuplicateResolutionJob.asReadonly();
 
   // ── Location Address Dialog Setters ────────────────────────────────────
 
   setLocationAddressDialogOpen(value: boolean): void {
-    this.locationAddressDialogOpen.set(value);
+    this._locationAddressDialogOpen.set(value);
   }
 
   setLocationAddressDialogQuery(value: string): void {
-    this.locationAddressDialogQuery.set(value);
+    this._locationAddressDialogQuery.set(value);
   }
 
   setLocationAddressDialogLoading(value: boolean): void {
-    this.locationAddressDialogLoading.set(value);
+    this._locationAddressDialogLoading.set(value);
   }
 
   setLocationAddressDialogSuggestions(value: ForwardGeocodeResult[]): void {
-    this.locationAddressDialogSuggestions.set(value);
+    this._locationAddressDialogSuggestions.set(value);
   }
 
   setPendingLocationAddressJob(job: UploadJob | null): void {
-    this.pendingLocationAddressJob.set(job);
+    this._pendingLocationAddressJob.set(job);
   }
 
   getLocationAddressSearchTimeout(): ReturnType<typeof setTimeout> | null {
@@ -73,56 +107,56 @@ export class UploadPanelDialogSignals {
   // ── Project Selection Dialog Setters ───────────────────────────────────
 
   setProjectSelectionDialogOpen(value: boolean): void {
-    this.projectSelectionDialogOpen.set(value);
+    this._projectSelectionDialogOpen.set(value);
   }
 
   setProjectSelectionDialogTitle(value: string): void {
-    this.projectSelectionDialogTitle.set(value);
+    this._projectSelectionDialogTitle.set(value);
   }
 
   setProjectSelectionDialogMessage(value: string): void {
-    this.projectSelectionDialogMessage.set(value);
+    this._projectSelectionDialogMessage.set(value);
   }
 
   setProjectSelectionDialogOptions(value: ReadonlyArray<ProjectSelectOption>): void {
-    this.projectSelectionDialogOptions.set(value);
+    this._projectSelectionDialogOptions.set(value);
   }
 
   setProjectSelectionDialogSelectedId(value: string | null): void {
-    this.projectSelectionDialogSelectedId.set(value);
+    this._projectSelectionDialogSelectedId.set(value);
   }
 
   setPendingProjectAssignmentJob(job: UploadJob | null): void {
-    this.pendingProjectAssignmentJob.set(job);
+    this._pendingProjectAssignmentJob.set(job);
   }
 
   setProjectNameDialogOpen(value: boolean): void {
-    this.projectNameDialogOpen.set(value);
+    this._projectNameDialogOpen.set(value);
   }
 
   setProjectNameDialogTitle(value: string): void {
-    this.projectNameDialogTitle.set(value);
+    this._projectNameDialogTitle.set(value);
   }
 
   setProjectNameDialogMessage(value: string): void {
-    this.projectNameDialogMessage.set(value);
+    this._projectNameDialogMessage.set(value);
   }
 
   setProjectNameDialogInitialValue(value: string): void {
-    this.projectNameDialogInitialValue.set(value);
+    this._projectNameDialogInitialValue.set(value);
   }
 
   // ── Duplicate Resolution Dialog Setters ────────────────────────────────
 
   setDuplicateResolutionDialogOpen(value: boolean): void {
-    this.duplicateResolutionDialogOpen.set(value);
+    this._duplicateResolutionDialogOpen.set(value);
   }
 
   setDuplicateResolutionApplyToBatch(value: boolean): void {
-    this.duplicateResolutionApplyToBatch.set(value);
+    this._duplicateResolutionApplyToBatch.set(value);
   }
 
   setPendingDuplicateResolutionJob(job: UploadJob | null): void {
-    this.pendingDuplicateResolutionJob.set(job);
+    this._pendingDuplicateResolutionJob.set(job);
   }
 }

--- a/apps/web/src/app/features/upload/upload-panel-input-handlers.ts
+++ b/apps/web/src/app/features/upload/upload-panel-input-handlers.ts
@@ -17,24 +17,25 @@ export class UploadPanelInputHandlersService {
   private readonly uploadSignals = inject(UploadPanelSignalsService);
   private readonly workspaceView = inject(WorkspaceViewService);
 
-  readonly isDragging = signal(false);
+  private readonly _isDragging = signal(false);
+  readonly isDragging = this._isDragging.asReadonly();
 
   onDragOver(event: DragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    this.isDragging.set(true);
+    this._isDragging.set(true);
   }
 
   onDragLeave(event: DragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    this.isDragging.set(false);
+    this._isDragging.set(false);
   }
 
   onDrop(event: DragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    this.isDragging.set(false);
+    this._isDragging.set(false);
     const files = event.dataTransfer?.files;
     if (files && files.length > 0) {
       this.uploadManager.submit(Array.from(files), {

--- a/apps/web/src/app/features/upload/upload-panel-lane-handlers.ts
+++ b/apps/web/src/app/features/upload/upload-panel-lane-handlers.ts
@@ -12,7 +12,7 @@ export class UploadPanelLaneHandlersService {
   private readonly signals = inject(UploadPanelSignalsService);
 
   setSelectedLane(lane: UploadLane): void {
-    this.signals.selectedLane.set(lane);
+    this.signals.setSelectedLane(lane);
   }
 
   onLaneSwitchValueChange(value: string | null): void {

--- a/apps/web/src/app/features/upload/upload-panel-lifecycle.service.ts
+++ b/apps/web/src/app/features/upload/upload-panel-lifecycle.service.ts
@@ -24,7 +24,9 @@ export class UploadPanelLifecycleService {
 
   // ── Issue attention pulse ──────────────────────────────────────────────────
 
-  readonly issueAttentionPulse = signal(false);
+  private readonly _issueAttentionPulse = signal(false);
+  readonly issueAttentionPulse = this._issueAttentionPulse.asReadonly();
+
   private issueAttentionTimer: ReturnType<typeof setTimeout> | null = null;
   private subscriptionsInitialized = false;
 
@@ -84,12 +86,12 @@ export class UploadPanelLifecycleService {
   // ── Private ────────────────────────────────────────────────────────────────
 
   private triggerIssueAttentionPulse(): void {
-    this.issueAttentionPulse.set(true);
+    this._issueAttentionPulse.set(true);
     if (this.issueAttentionTimer) {
       clearTimeout(this.issueAttentionTimer);
     }
     this.issueAttentionTimer = setTimeout(() => {
-      this.issueAttentionPulse.set(false);
+      this._issueAttentionPulse.set(false);
       this.issueAttentionTimer = null;
     }, UploadPanelLifecycleService.ISSUE_ATTENTION_RESET_MS);
   }

--- a/apps/web/src/app/features/upload/upload-panel-signals.service.ts
+++ b/apps/web/src/app/features/upload/upload-panel-signals.service.ts
@@ -45,8 +45,11 @@ export class UploadPanelSignalsService {
 
   // ── UI State (lane selection) ──────────────────────────────────────────────
 
-  readonly selectedLane = signal<UploadLane>('uploading');
-  readonly locationRequirementMode = signal<UploadLocationRequirementMode>('optional');
+  private readonly _selectedLane = signal<UploadLane>('uploading');
+  readonly selectedLane = this._selectedLane.asReadonly();
+
+  private readonly _locationRequirementMode = signal<UploadLocationRequirementMode>('optional');
+  readonly locationRequirementMode = this._locationRequirementMode.asReadonly();
 
   private readonly sessionLocationModeOverrides = signal<
     Map<string, UploadLocationRequirementMode>
@@ -54,8 +57,8 @@ export class UploadPanelSignalsService {
 
   // ── Computed (derived state) ───────────────────────────────────────────────
 
-  readonly effectiveLane = computed<UploadLane>(() => this.selectedLane());
-  readonly laneJobs = computed(() => this.state.laneBuckets()[this.selectedLane()]);
+  readonly effectiveLane = computed<UploadLane>(() => this._selectedLane());
+  readonly laneJobs = computed(() => this.state.laneBuckets()[this._selectedLane()]);
 
   private readonly activeProjectId = computed<string | undefined>(() => {
     const selected = this.workspaceView.selectedProjectIds();
@@ -68,13 +71,13 @@ export class UploadPanelSignalsService {
       const overrides = this.sessionLocationModeOverrides();
 
       if (!activeProjectId) {
-        this.locationRequirementMode.set('optional');
+        this._locationRequirementMode.set('optional');
         return;
       }
 
       const overridden = overrides.get(activeProjectId);
       if (overridden) {
-        this.locationRequirementMode.set(overridden);
+        this._locationRequirementMode.set(overridden);
         return;
       }
 
@@ -82,8 +85,12 @@ export class UploadPanelSignalsService {
     });
   }
 
+  setSelectedLane(lane: UploadLane): void {
+    this._selectedLane.set(lane);
+  }
+
   setLocationRequirementMode(mode: UploadLocationRequirementMode): void {
-    this.locationRequirementMode.set(mode);
+    this._locationRequirementMode.set(mode);
 
     const activeProjectId = this.activeProjectId();
     if (!activeProjectId) {
@@ -102,7 +109,7 @@ export class UploadPanelSignalsService {
     const project = projects.find((item) => item.id === projectId);
 
     if (!project) {
-      this.locationRequirementMode.set('optional');
+      this._locationRequirementMode.set('optional');
       return;
     }
 
@@ -114,6 +121,6 @@ export class UploadPanelSignalsService {
       return;
     }
 
-    this.locationRequirementMode.set(project.locationRequired ? 'required' : 'optional');
+    this._locationRequirementMode.set(project.locationRequired ? 'required' : 'optional');
   }
 }

--- a/apps/web/src/app/features/upload/upload-panel.component.html
+++ b/apps/web/src/app/features/upload/upload-panel.component.html
@@ -42,7 +42,7 @@
       [class.upload-panel__dropzone--dragging]="isDragging()"
       (dragover)="inputHandlers.onDragOver($event)"
       (dragleave)="inputHandlers.onDragLeave($event)"
-      (drop)="inputHandlers.onDrop($event); selectedLane.set('uploading')"
+      (drop)="inputHandlers.onDrop($event); laneHandlers.setSelectedLane('uploading')"
       role="button"
       tabindex="0"
       aria-label="Drag files here or click to select"
@@ -74,7 +74,7 @@
       multiple
       aria-hidden="true"
       tabindex="-1"
-      (change)="inputHandlers.onFileInputChange($event); selectedLane.set('uploading')"
+      (change)="inputHandlers.onFileInputChange($event); laneHandlers.setSelectedLane('uploading')"
     />
 
     <button
@@ -131,7 +131,7 @@
       capture="environment"
       aria-hidden="true"
       tabindex="-1"
-      (change)="inputHandlers.onCaptureInputChange($event); selectedLane.set('uploading')"
+      (change)="inputHandlers.onCaptureInputChange($event); laneHandlers.setSelectedLane('uploading')"
     />
 
     <input
@@ -143,7 +143,7 @@
       directory
       aria-hidden="true"
       tabindex="-1"
-      (change)="inputHandlers.onFolderInputChange($event); selectedLane.set('uploading')"
+      (change)="inputHandlers.onFolderInputChange($event); laneHandlers.setSelectedLane('uploading')"
     />
   </div>
 

--- a/apps/web/src/app/layout/authenticated-app-layout.component.ts
+++ b/apps/web/src/app/layout/authenticated-app-layout.component.ts
@@ -73,7 +73,7 @@ export class AuthenticatedAppLayoutComponent implements WorkspacePaneShellHost {
     effect(() => {
       const id = this.workspacePaneObserver.detailImageId$();
       if (this.shellState.detailMediaId() !== id) {
-        this.shellState.detailMediaId.set(id);
+        this.shellState.setDetailMediaId(id);
       }
     });
 
@@ -89,22 +89,22 @@ export class AuthenticatedAppLayoutComponent implements WorkspacePaneShellHost {
 
   openDetailView(mediaId: string): void {
     if (!this.shellState.photoPanelOpen()) {
-      this.shellState.workspacePaneWidth.set(this.getWorkspacePaneOpeningWidth());
+      this.shellState.setWorkspacePaneWidth(this.getWorkspacePaneOpeningWidth());
     }
-    this.shellState.detailMediaId.set(mediaId);
+    this.shellState.setDetailMediaId(mediaId);
     this.workspacePaneObserver.setDetailImageId(mediaId);
-    this.shellState.photoPanelOpen.set(true);
+    this.shellState.setPhotoPanelOpen(true);
   }
 
   closeDetailView(): void {
-    this.shellState.detailMediaId.set(null);
+    this.shellState.setDetailMediaId(null);
     this.workspacePaneObserver.setDetailImageId(null);
   }
 
   closeWorkspacePane(): void {
     this.mapLayoutEffects.getMapEffects()?.onWorkspacePaneClosing();
-    this.shellState.photoPanelOpen.set(false);
-    this.shellState.detailMediaId.set(null);
+    this.shellState.setPhotoPanelOpen(false);
+    this.shellState.setDetailMediaId(null);
     this.workspacePaneObserver.setDetailImageId(null);
     this.workspacePaneObserver.setOpen(false);
     this.workspaceViewService.clearActiveSelection();
@@ -114,7 +114,7 @@ export class AuthenticatedAppLayoutComponent implements WorkspacePaneShellHost {
 
   onWorkspaceWidthChange(newWidth: number): void {
     const clampedWidth = this.clampWorkspacePaneWidth(newWidth);
-    this.shellState.workspacePaneWidth.set(clampedWidth);
+    this.shellState.setWorkspacePaneWidth(clampedWidth);
     this.persistWorkspacePaneWidthPreference(clampedWidth);
     this.mapLayoutEffects.getMapEffects()?.invalidateMapSize();
   }
@@ -128,7 +128,7 @@ export class AuthenticatedAppLayoutComponent implements WorkspacePaneShellHost {
     if (!currentRequest || currentRequest.requestId !== requestId) {
       return;
     }
-    this.shellState.detailAddressSearchRequest.set(null);
+    this.shellState.setDetailAddressSearchRequest(null);
   }
 
   onZoomToLocationRequested(event: {
@@ -211,7 +211,7 @@ export class AuthenticatedAppLayoutComponent implements WorkspacePaneShellHost {
 
     const clampedWidth = this.clampWorkspacePaneWidth(parsedWidth);
     this.preferredWorkspacePaneWidth.set(clampedWidth);
-    this.shellState.workspacePaneWidth.set(clampedWidth);
+    this.shellState.setWorkspacePaneWidth(clampedWidth);
   }
 
   private persistWorkspacePaneWidthPreference(width: number): void {

--- a/apps/web/src/app/shared/workspace-pane/footer/workspace-pane-footer/workspace-pane-footer.component.ts
+++ b/apps/web/src/app/shared/workspace-pane/footer/workspace-pane-footer/workspace-pane-footer.component.ts
@@ -5,10 +5,11 @@ import { ShareSetService } from '../../../../core/share-set/share-set.service';
 import { MediaDownloadService } from '../../../../core/media-download/media-download.service';
 import { ToastService } from '../../../../core/toast/toast.service';
 import { I18nService } from '../../../../core/i18n/i18n.service';
-import { SupabaseService } from '../../../../core/supabase/supabase.service';
 import { GeocodingService } from '../../../../core/geocoding/geocoding.service';
 import { MediaLocationUpdateService } from '../../../../core/media-location-update/media-location-update.service';
 import { WorkspaceViewService } from '../../../../core/workspace-view/workspace-view.service';
+import { MediaQueryService } from '../../../../core/media-query/media-query.service';
+import { ProjectsService } from '../../../../core/projects/projects.service';
 import { ActionEngineService } from '../../../../core/action/action-engine.service';
 import { ACTION_CONTEXT_IDS } from '../../../../core/action/action-context-ids';
 import {
@@ -60,10 +61,11 @@ export class WorkspacePaneFooterComponent {
   protected readonly selectionService = inject(WorkspaceSelectionService);
   private readonly actionEngine = inject(ActionEngineService);
   private readonly i18nService = inject(I18nService);
-  private readonly supabaseService = inject(SupabaseService);
   private readonly geocodingService = inject(GeocodingService);
   private readonly mediaLocationUpdateService = inject(MediaLocationUpdateService);
   private readonly workspaceViewService = inject(WorkspaceViewService);
+  private readonly mediaQueryService = inject(MediaQueryService);
+  private readonly projectsService = inject(ProjectsService);
   private readonly shareSetService = inject(ShareSetService);
   private readonly mediaDownloadService = inject(MediaDownloadService);
   private readonly toastService = inject(ToastService);
@@ -146,17 +148,14 @@ export class WorkspacePaneFooterComponent {
 
     this.pending.set(true);
     try {
-      const rows = selectedMediaItemIds.map((mediaItemId) => ({
-        media_item_id: mediaItemId,
-        project_id: projectId,
-      }));
-      const { error } = await this.supabaseService.client
-        .from('media_projects')
-        .upsert(rows, { onConflict: 'media_item_id,project_id', ignoreDuplicates: true });
+      const result = await this.projectsService.assignMediaItemsToProject(
+        selectedMediaItemIds,
+        projectId,
+      );
 
-      if (error) {
+      if (!result.ok) {
         this.toastService.show({
-          message: error.message,
+          message: result.errorMessage ?? '',
           type: 'error',
         });
         return;
@@ -236,7 +235,7 @@ export class WorkspacePaneFooterComponent {
       }
 
       const selectedImageIds = this.selectionService.selectedMediaIds();
-      this.workspaceViewService.rawImages.update((images) =>
+      this.workspaceViewService.updateRawImages((images) =>
         images.map((image) =>
           selectedImageIds.has(image.id)
             ? {
@@ -285,18 +284,15 @@ export class WorkspacePaneFooterComponent {
 
     this.pending.set(true);
     try {
-      const { error } = await this.supabaseService.client
-        .from('media_items')
-        .delete()
-        .in('id', selectedMediaItemIds);
+      const result = await this.mediaQueryService.deleteMediaItems(selectedMediaItemIds);
 
-      if (error) {
-        this.toastService.show({ message: error.message, type: 'error' });
+      if (!result.ok) {
+        this.toastService.show({ message: result.errorMessage ?? '', type: 'error' });
         return;
       }
 
       const selectedIds = this.selectionService.selectedMediaIds();
-      this.workspaceViewService.rawImages.update((images) =>
+      this.workspaceViewService.updateRawImages((images) =>
         images.filter((image) => !selectedIds.has(image.id)),
       );
       this.selectionService.clearSelection();
@@ -442,12 +438,9 @@ export class WorkspacePaneFooterComponent {
   private async openProjectDialog(): Promise<void> {
     this.pending.set(true);
     try {
-      const { data, error } = await this.supabaseService.client
-        .from('projects')
-        .select('id,name')
-        .order('name', { ascending: true });
+      const projectOptions = await this.projectsService.loadProjectSelectOptions();
 
-      if (error || !Array.isArray(data) || data.length === 0) {
+      if (projectOptions.length === 0) {
         this.toastService.show({
           message: this.t('workspace.export.error.noProjectsAvailable', 'No projects available.'),
           type: 'warning',
@@ -455,14 +448,7 @@ export class WorkspacePaneFooterComponent {
         return;
       }
 
-      this.projectOptions.set(
-        data
-          .filter(
-            (row): row is { id: string; name: string } =>
-              typeof row.id === 'string' && typeof row.name === 'string' && row.name.length > 0,
-          )
-          .map((row) => ({ id: row.id, name: row.name })),
-      );
+      this.projectOptions.set(projectOptions);
       this.projectDialogSelectedId.set(this.projectOptions()[0]?.id ?? null);
       this.projectDialogOpen.set(true);
     } finally {
@@ -472,27 +458,7 @@ export class WorkspacePaneFooterComponent {
 
   private async resolveSelectedMediaItemIds(): Promise<string[]> {
     const selectedIds = Array.from(this.selectionService.selectedMediaIds());
-    if (selectedIds.length === 0) {
-      return [];
-    }
-
-    const idList = selectedIds.join(',');
-    const { data, error } = await this.supabaseService.client
-      .from('media_items')
-      .select('id,source_image_id')
-      .or(`id.in.(${idList}),source_image_id.in.(${idList})`);
-
-    if (error || !Array.isArray(data)) {
-      return [];
-    }
-
-    return Array.from(
-      new Set(
-        data
-          .map((row) => (typeof row.id === 'string' ? row.id : null))
-          .filter((id): id is string => !!id),
-      ),
-    );
+    return this.mediaQueryService.resolveMediaItemIdsByLookupIds(selectedIds);
   }
 
   private async removeFromProject(): Promise<void> {
@@ -507,18 +473,15 @@ export class WorkspacePaneFooterComponent {
 
     this.pending.set(true);
     try {
-      const { error } = await this.supabaseService.client
-        .from('media_projects')
-        .delete()
-        .in('media_item_id', selectedMediaItemIds);
+      const result = await this.projectsService.removeMediaItemsFromProjects(selectedMediaItemIds);
 
-      if (error) {
-        this.toastService.show({ message: error.message, type: 'error' });
+      if (!result.ok) {
+        this.toastService.show({ message: result.errorMessage ?? '', type: 'error' });
         return;
       }
 
       const selectedImageIds = this.selectionService.selectedMediaIds();
-      this.workspaceViewService.rawImages.update((images) =>
+      this.workspaceViewService.updateRawImages((images) =>
         images.map((image) =>
           selectedImageIds.has(image.id)
             ? {

--- a/apps/web/src/app/shared/workspace-pane/media-detail/media-detail-media-events.helper.ts
+++ b/apps/web/src/app/shared/workspace-pane/media-detail/media-detail-media-events.helper.ts
@@ -78,7 +78,7 @@ export class MediaDetailMediaEventsHelper {
   }
 
   private updateGridCache(imageId: string, newStoragePath: string): void {
-    this.deps.services.workspaceView.rawImages.update((all) =>
+    this.deps.services.workspaceView.updateRawImages((all) =>
       all.map((wi) =>
         wi.id === imageId
           ? {

--- a/apps/web/src/app/shared/workspace-pane/selected-items/workspace-selected-items-grid.component.ts
+++ b/apps/web/src/app/shared/workspace-pane/selected-items/workspace-selected-items-grid.component.ts
@@ -16,13 +16,14 @@ import {
 import { WorkspaceViewService } from '../../../core/workspace-view/workspace-view.service';
 import { FilterService } from '../../../core/filter/filter.service';
 import { WorkspaceSelectionService } from '../../../core/workspace-selection/workspace-selection.service';
-import { SupabaseService } from '../../../core/supabase/supabase.service';
 import { ToastService } from '../../../core/toast/toast.service';
 import { I18nService } from '../../../core/i18n/i18n.service';
 import { GeocodingService } from '../../../core/geocoding/geocoding.service';
 import { MediaLocationUpdateService } from '../../../core/media-location-update/media-location-update.service';
 import { ShareSetService } from '../../../core/share-set/share-set.service';
 import { MediaDownloadService } from '../../../core/media-download/media-download.service';
+import { MediaQueryService } from '../../../core/media-query/media-query.service';
+import { ProjectsService } from '../../../core/projects/projects.service';
 import { LocationResolverService } from '../../../core/location-resolver/location-resolver.service';
 import type {
   GroupedSection,
@@ -254,7 +255,6 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
   protected readonly viewService = inject(WorkspaceViewService);
   protected readonly selectionService = inject(WorkspaceSelectionService);
   private readonly filterService = inject(FilterService);
-  private readonly supabaseService = inject(SupabaseService);
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly geocodingService = inject(GeocodingService);
@@ -262,6 +262,8 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
   private readonly locationResolverService = inject(LocationResolverService);
   private readonly shareSetService = inject(ShareSetService);
   private readonly mediaDownloadService = inject(MediaDownloadService);
+  private readonly mediaQueryService = inject(MediaQueryService);
+  private readonly projectsService = inject(ProjectsService);
   readonly t = (key: string, fallback = '') => this.i18nService.t(key, fallback);
   readonly currentLanguage = this.i18nService.language;
 
@@ -466,7 +468,7 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
 
   clearFilters(): void {
     this.filterService.clearAll();
-    this.viewService.selectedProjectIds.set(new Set());
+    this.viewService.setSelectedProjectIds(new Set());
   }
 
   onScroll(): void {
@@ -664,7 +666,7 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
     }
 
     const selectedImageIds = this.selectionService.selectedMediaIds();
-    this.viewService.rawImages.update((images) =>
+    this.viewService.updateRawImages((images) =>
       images.map((image) =>
         selectedImageIds.has(image.id)
           ? {
@@ -701,16 +703,13 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
       return;
     }
 
-    const rows = selectedMediaItemIds.map((mediaItemId) => ({
-      media_item_id: mediaItemId,
-      project_id: projectId,
-    }));
-    const { error } = await this.supabaseService.client
-      .from('media_projects')
-      .upsert(rows, { onConflict: 'media_item_id,project_id', ignoreDuplicates: true });
+    const result = await this.projectsService.assignMediaItemsToProject(
+      selectedMediaItemIds,
+      projectId,
+    );
 
-    if (error) {
-      this.toastService.show({ message: error.message, type: 'error' });
+    if (!result.ok) {
+      this.toastService.show({ message: result.errorMessage ?? '', type: 'error' });
       return;
     }
 
@@ -1010,12 +1009,9 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
   }
 
   private async openProjectDialog(): Promise<void> {
-    const { data, error } = await this.supabaseService.client
-      .from('projects')
-      .select('id,name')
-      .order('name', { ascending: true });
+    const projectOptions = await this.projectsService.loadProjectSelectOptions();
 
-    if (error || !Array.isArray(data) || data.length === 0) {
+    if (projectOptions.length === 0) {
       this.toastService.show({
         message: this.t('workspace.export.error.noProjectsAvailable', 'No projects available.'),
         type: 'warning',
@@ -1023,41 +1019,14 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
       return;
     }
 
-    this.projectOptions.set(
-      data
-        .filter(
-          (row): row is { id: string; name: string } =>
-            typeof row.id === 'string' && typeof row.name === 'string' && row.name.length > 0,
-        )
-        .map((row) => ({ id: row.id, name: row.name })),
-    );
+    this.projectOptions.set(projectOptions);
     this.projectDialogSelectedId.set(this.projectOptions()[0]?.id ?? null);
     this.projectDialogOpen.set(true);
   }
 
   private async resolveSelectedMediaItemIds(): Promise<string[]> {
     const selectedIds = Array.from(this.selectionService.selectedMediaIds());
-    if (selectedIds.length === 0) {
-      return [];
-    }
-
-    const idList = selectedIds.join(',');
-    const { data, error } = await this.supabaseService.client
-      .from('media_items')
-      .select('id,source_image_id')
-      .or(`id.in.(${idList}),source_image_id.in.(${idList})`);
-
-    if (error || !Array.isArray(data)) {
-      return [];
-    }
-
-    return Array.from(
-      new Set(
-        data
-          .map((row) => (typeof row.id === 'string' ? row.id : null))
-          .filter((id): id is string => !!id),
-      ),
-    );
+    return this.mediaQueryService.resolveMediaItemIdsByLookupIds(selectedIds);
   }
 
   private async removeSelectedFromProject(): Promise<void> {
@@ -1070,18 +1039,15 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
       return;
     }
 
-    const { error } = await this.supabaseService.client
-      .from('media_projects')
-      .delete()
-      .in('media_item_id', selectedMediaItemIds);
+    const result = await this.projectsService.removeMediaItemsFromProjects(selectedMediaItemIds);
 
-    if (error) {
-      this.toastService.show({ message: error.message, type: 'error' });
+    if (!result.ok) {
+      this.toastService.show({ message: result.errorMessage ?? '', type: 'error' });
       return;
     }
 
     const selectedImageIds = this.selectionService.selectedMediaIds();
-    this.viewService.rawImages.update((images) =>
+    this.viewService.updateRawImages((images) =>
       images.map((image) =>
         selectedImageIds.has(image.id)
           ? {
@@ -1113,17 +1079,14 @@ export class WorkspaceSelectedItemsGridComponent implements OnDestroy {
     }
 
     const selectedIds = this.selectionService.selectedMediaIds();
-    const { error } = await this.supabaseService.client
-      .from('media_items')
-      .delete()
-      .in('id', selectedMediaItemIds);
+    const result = await this.mediaQueryService.deleteMediaItems(selectedMediaItemIds);
 
-    if (error) {
-      this.toastService.show({ message: error.message, type: 'error' });
+    if (!result.ok) {
+      this.toastService.show({ message: result.errorMessage ?? '', type: 'error' });
       return;
     }
 
-    this.viewService.rawImages.update((images) =>
+    this.viewService.updateRawImages((images) =>
       images.filter((image) => !selectedIds.has(image.id)),
     );
     this.selectionService.clearSelection();

--- a/apps/web/src/app/shared/workspace-pane/toolbar/workspace-toolbar/workspace-toolbar.component.ts
+++ b/apps/web/src/app/shared/workspace-pane/toolbar/workspace-toolbar/workspace-toolbar.component.ts
@@ -128,17 +128,17 @@ export class WorkspaceToolbarComponent implements OnInit {
   onGroupingsChanged(active: GroupingProperty[]): void {
     this.activeGroupings.set(active);
     // Push to WorkspaceViewService
-    this.viewService.activeGroupings.set(
+    this.viewService.setActiveGroupings(
       active.map((g) => ({ id: g.id, label: g.label, icon: g.icon }) as MetadataFieldRef),
     );
   }
 
   onSortChanged(sortConfigs: SortConfig[]): void {
-    this.viewService.activeSorts.set(sortConfigs);
+    this.viewService.setActiveSorts(sortConfigs);
   }
 
   onProjectsChanged(selectedIds: Set<string>): void {
-    this.viewService.selectedProjectIds.set(selectedIds);
+    this.viewService.setSelectedProjectIds(selectedIds);
   }
 
   toggleDropdown(id: ToolbarDropdown, event: MouseEvent): void {


### PR DESCRIPTION
## Summary
- Moves MapShell Supabase and Leaflet boundary work behind focused services/adapters for #35 and #36.
- Extracts shared workspace Supabase operations for #37 and #38, and keeps component files free of direct table queries.
- Encapsulates writable service signals and updates parser services to use inject() for #34 and #39.

## Test plan
- cd apps/web && npm run build
- rg Leaflet imports in feature components -> no matches
- rg component .from(' calls -> no matches
- rg public service signal(...) surfaces -> no matches
- npx vitest run src/app/core/location-path-parser/location-path-parser.service.spec.ts src/app/core/filename-parser/filename-parser.service.spec.ts
