### PR TITLE
Add org admin sections, search provider system, and filter toolbar specs

### DIFF
--- a/docs/element-specs/README.md
+++ b/docs/element-specs/README.md
@@ -208,7 +208,8 @@ Order: grouped by UI layer from shell foundations through pages and cross-cuttin
 - ✅ `filter-panel.md` — Filter Panel (accordion filters)
 - ✅ `filter-dropdown.md` — Filter Dropdown (shared dropdown primitive)
 - ✅ `projects-dropdown.md` — Projects Dropdown (project selection filter)
-- ✅ `active-filter-chips.md` — Active Filter Chips Strip
+- ✅ `active-filter-chips.md` — Active Filter Chips Strip (superseded by `filter-toolbar.md`)
+- ✅ `filter-toolbar.md` — Filter Toolbar (reusable docked filter chip row below search bars)
 - ✅ `image-detail-view.md` — Image Detail View (parent: layout, nav, quick info)
   - ✅ `image-detail-photo-viewer.md` — Photo Viewer (progressive loading, lightbox, replace/upload)
   - ✅ `image-detail-inline-editing.md` — Inline Editing (property rows, address search)
@@ -238,12 +239,13 @@ Order: grouped by UI layer from shell foundations through pages and cross-cuttin
 - ✅ `custom-properties.md` — Custom Properties (user-defined metadata schema)
 - ✅ `language-locale-settings.md` — Language & Locale Settings (English/German switch with persistence and formatting context)
 - ✅ `account-settings-section.md` — Account Settings Section (identity context + confirmed logout flow in Settings Overlay)
+- ✅ `org-administration-section.md` — Org Administration Section (admin-only members, sharing, activity, and org settings in Settings Overlay)
 
 ### Planned / Missing Specs
 
 - ✅ `qr-invite-flow.md` — QR invite and join flow (invite creation, scan/join, failure states)
-- 🔲 `role-system.md` — Role and permission system UI (owner/admin/member permissions)
-- 🔲 `slash-commands.md` — Slash command palette and action execution UX
+- ✅ `org-administration-section.md` — Role and permission system UI (covers the former `role-system.md` placeholder; see `docs/org-administration-audit.md` for the phased plan)
+- 🔲 `slash-commands.md` — Slash command palette and action execution UX (operator groundwork planned in `implementation-blueprints/universal-search-provider-system.md`)
 
 ## Priority
 

--- a/docs/element-specs/active-filter-chips.md
+++ b/docs/element-specs/active-filter-chips.md
@@ -1,5 +1,6 @@
 # Active Filter Chips
 
+> **Superseded by:** [filter-toolbar.md](filter-toolbar.md) — the reusable Filter Toolbar absorbs this element's acceptance criteria and adds keyword-operator integration. Do not implement this spec; it is retained for historical context.
 > **Blueprint:** [implementation-blueprints/active-filter-chips.md](../implementation-blueprints/active-filter-chips.md)
 
 ## What It Is

--- a/docs/element-specs/filter-toolbar.md
+++ b/docs/element-specs/filter-toolbar.md
@@ -1,0 +1,136 @@
+# Filter Toolbar
+
+> **Blueprint:** [implementation-blueprints/universal-search-provider-system.md](../implementation-blueprints/universal-search-provider-system.md)
+> **Supersedes:** [active-filter-chips.md](active-filter-chips.md) — do not implement both.
+
+## What It Is
+
+A floating row of filter chips that docks directly below a search bar and shows every active filter as a toggleable, removable pill. It is a reusable component — the map search bar hosts it first, and any future search surface (workspace/image detail, photos page) docks the same component with zero new wiring.
+
+## What It Looks Like
+
+A horizontal flex-wrap row floating just below the host search bar, same width as the search surface, with a small gap so it reads as a separate docked element. Chips are compact pills on `--color-bg-elevated`: a leading provider icon (folder for project, calendar for time range, tag for metadata), a label like "Projekt: Halle West", and a trailing 1rem × button. The chip for a filter created seconds ago animates in with a short fade/slide. The row is invisible when no filters are active — it occupies no space and never renders an empty container. Wraps to multiple lines when needed; on mobile it scrolls horizontally instead of wrapping beyond two lines.
+
+## Where It Lives
+
+- **Route**: wherever its host search bar lives — v1: map page only
+- **Parent**: `MapShellComponent` (`features/map/map-shell/map-shell.component.ts`), rendered immediately below `SearchBarComponent` in the Map Zone (z-order below the open results panel so the dropdown overlays the toolbar)
+- **Appears when**: `FilterService.activeCount() > 0`
+- **Reusability contract**: the component takes no host-specific inputs; docking on a new surface = placing `<app-filter-toolbar/>` under that surface's search bar. Filter state is global (`FilterService`), so all surfaces show the same chips by design.
+
+## Actions
+
+| #   | User Action                                              | System Response                                                                       | Triggers                                |
+| --- | -------------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------- |
+| 1   | Commits `+project` candidate in the search bar           | Chip appears in toolbar with enter animation; search input clears                      | `FilterService.add()` via operator bridge |
+| 2   | Clicks a chip's × (or commits `-project` in search bar)  | Chip leaves; filtered surfaces re-evaluate                                             | `FilterService.remove()`                  |
+| 3   | Re-selects an entity that is already an active chip      | Chip toggles **off** (operator path and chip path are equivalent)                      | `FilterService.toggle()`                  |
+| 4   | Clicks the chip body (not the ×)                         | Chip enters "armed" focus state; Backspace/Delete removes it; Escape disarms           | Keyboard removal affordance               |
+| 5   | Activates "Clear all" (shown when ≥ 3 chips)             | All filters removed                                                                    | `FilterService.clear()`                   |
+| 6   | Filters change from anywhere else (filter panel, operators) | Toolbar updates reactively; no own copy of state                                     | `rules` signal                            |
+| 7   | Last chip removed                                        | Toolbar disappears entirely (no empty shell)                                           | `activeCount() === 0`                     |
+| 8   | Tabs into the toolbar                                    | Chips are focusable in order; × reachable; `aria-label` announces filter description    | a11y                                      |
+
+## Component Hierarchy
+
+```
+FilterToolbar                              ← flex-wrap row, docked below host search bar, gap-2
+├── FilterChip × N                         ← pill, --color-bg-elevated, focusable
+│   ├── ProviderIcon                       ← 1rem leading icon by rule property
+│   ├── ChipLabel                          ← "Projekt: Halle West", truncates > 12rem
+│   └── RemoveButton (×)                   ← 1rem ghost, aria-label "Filter entfernen: …"
+└── [≥ 3 chips] ClearAllButton             ← ghost text button "Clear all"
+```
+
+### Wiring Flow (Mermaid)
+
+```mermaid
+flowchart LR
+  SB[Host SearchBarComponent] -->|"+/- operator commits"| OPS[search-operators bridge]
+  OPS --> FS[FilterService]
+  FT[FilterToolbarComponent] -->|toggle / remove / clear| FS
+  FS -->|rules signal| FT
+  FS -->|rules signal| MAP[Map markers]
+  FS -->|rules signal| WS[Workspace grid / detail view]
+```
+
+### Data Flow (Mermaid)
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant SB as Search Bar
+  participant FS as FilterService
+  participant FT as FilterToolbar
+
+  U->>SB: types "+halle", commits "Halle West"
+  SB->>FS: add(rule from provider.toFilterRule)
+  FS-->>FT: rules() emits → chip renders, input clears
+  U->>FT: clicks × on chip
+  FT->>FS: remove(rule.id)
+  FS-->>FT: rules() emits → chip leaves, surfaces re-query
+```
+
+## Data
+
+| Field          | Source                                  | Type           |
+| -------------- | ---------------------------------------- | -------------- |
+| Active filters | `FilterService.rules()` signal           | `FilterRule[]` |
+| Chip labels    | Derived: provider noun (i18n) + rule value | `string`     |
+
+No Supabase access — purely a view over `FilterService`.
+
+## State
+
+No own state beyond a transient `armedChipId: string | null` for keyboard removal. Everything else is derived from `FilterService`; the toolbar must remain correct if filters are mutated by any other surface.
+
+## Settings
+
+- **Filter Toolbar**: chip overflow behavior (wrap vs horizontal scroll on mobile) and the chip-count threshold at which "Clear all" appears.
+
+## File Map
+
+| File                                                  | Purpose                                |
+| ----------------------------------------------------- | -------------------------------------- |
+| `shared/filter-toolbar/filter-toolbar.component.ts`   | Toolbar component (standalone, reusable) |
+| `shared/filter-toolbar/filter-toolbar.component.html` | Template                               |
+| `shared/filter-toolbar/filter-toolbar.component.scss` | Chip + row styles                      |
+| `shared/filter-toolbar/filter-toolbar.component.spec.ts` | Unit tests covering Actions table   |
+
+Placed in `shared/` (not `features/map/`) because the docking contract is host-agnostic.
+
+## Wiring
+
+### Injected Services
+
+- `FilterService` — single source of truth for rules; toolbar calls `add/remove/toggle/clear`.
+- `I18nService` — chip noun labels, remove/clear aria-labels (en/de/it).
+
+### Inputs / Outputs
+
+None. (Host-specific positioning is the host's CSS concern; the toolbar only guarantees its own row layout.)
+
+### Subscriptions
+
+- `FilterService.rules()` signal read in template (no manual teardown).
+
+### Supabase Calls
+
+None — delegated to nothing; the toolbar is state-view only.
+
+- Mount in `map-shell.component.html` directly below `<app-search-bar>`.
+- `FilterService` gains `toggle(rule)` and stable rule identity (`property + value` equality) so operator commits and chip clicks converge (blueprint phase 3).
+- New strings registered per the mandatory i18n workflow.
+
+## Acceptance Criteria
+
+- [ ] Invisible (zero footprint) when no filters are active
+- [ ] Chip appears with animation when a `+` operator commit or filter-panel action adds a rule, and the search input clears on operator commits
+- [ ] Clicking × removes exactly that filter and all filtered surfaces update
+- [ ] Re-selecting an already-active entity (via chip, `+`, or `#`-scoped commit) toggles the chip off — both paths produce identical `FilterService` state
+- [ ] `-` operator meta suggestions list current chips and removing via `-` is equivalent to clicking ×
+- [ ] Chips wrap gracefully on desktop and scroll horizontally on mobile
+- [ ] "Clear all" appears at ≥ 3 chips and removes everything
+- [ ] Chips are keyboard-focusable; Backspace/Delete removes an armed chip; aria-labels describe each filter
+- [ ] Search actions never reset chips (only explicit removal/clear does)
+- [ ] Docking the component under a second search bar requires no changes to the component itself

--- a/docs/element-specs/org-administration-section.md
+++ b/docs/element-specs/org-administration-section.md
@@ -1,0 +1,177 @@
+# Org Administration Section
+
+> **Audit & plan:** [org-administration-audit.md](../org-administration-audit.md) — read it first for the DB/RLS gaps each sub-section depends on.
+
+## What It Is
+
+A group of admin-only settings overlay sections — **Members**, **Sharing**, **Activity**, and **Organization** — that let an org admin manage membership and roles, revoke share links, review the audit trail, and rename the organization. Visible only to users with the `admin` role.
+
+## What It Looks Like
+
+Each sub-section is a standard settings overlay section: section header with icon + title + subtitle, followed by `.ui-container` panels of `.ui-item` rows. Members render as rows with an avatar-initial media slot, name + email label column, a role dropdown (shared dropdown primitive), and a ⋯ menu. Share sets and invites render as rows with monospace `token_prefix`, creator and expiry meta text, and a ghost "Revoke" button that turns into a confirm state on first click. Activity renders as a reverse-chronological list of compact rows: action icon, human-readable sentence, relative timestamp. Calm, warm styling consistent with existing sections — destructive actions use `--color-danger` text, never filled red buttons.
+
+## Where It Lives
+
+- **Route**: none — sections inside the Settings Overlay
+- **Parent**: `SettingsOverlayComponent` at `features/settings-overlay/settings-overlay.component.ts`
+- **Appears when**: settings overlay is open AND `OrgRoleService.isAdmin()` is true; the section entries are filtered out of `sectionList` for non-admins (UX only — RLS remains the security boundary)
+
+## Actions
+
+| #   | User Action                                   | System Response                                                                                  | Triggers                                  |
+| --- | --------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| 1   | Opens "Members" section                       | Loads member list via `list_org_members()` RPC                                                   | Supabase RPC                              |
+| 2   | Changes a member's role in the dropdown       | Calls `set_user_role()`; row updates optimistically, reverts on error                            | Supabase RPC + audit row                  |
+| 3   | Tries to demote/remove the last admin         | Action blocked with inline error "An organization needs at least one admin"                      | RPC error surfaced (DB-enforced)          |
+| 4   | Clicks ⋯ → "Remove from organization"         | Confirm dialog (shared `confirm-dialog`); on confirm calls `remove-member` edge function          | Edge function + audit row                 |
+| 5   | Opens "Sharing" section                       | Lists active share sets (creator, item count, created, expires)                                  | Supabase select on `share_sets`           |
+| 6   | Clicks "Revoke" on a share set, then confirms | Sets `revoked_at = now()`; row moves to the revoked group; existing links stop resolving         | Supabase update + audit row               |
+| 7   | Toggles "Show revoked & expired"              | Includes inactive share sets in the list (admin-read-all policy)                                 | Re-query                                  |
+| 8   | Opens "Activity" section                      | Loads latest 50 `audit_events`, newest first; "Load more" appends pages                          | Supabase select                           |
+| 9   | Filters activity by action type               | List re-queries with `action` filter                                                             | Re-query                                  |
+| 10  | Opens "Organization" section                  | Shows org name (editable), org id, member count                                                  | Supabase select                           |
+| 11  | Renames the org and saves                     | Updates `organizations.name`; toast confirms; audit row written                                  | Supabase update + audit row               |
+| 12  | Non-admin opens settings overlay              | None of these sections appear in the section list                                                | `sectionList` filtered by `isAdmin()`     |
+
+## Component Hierarchy
+
+```
+SettingsOverlay (existing)
+└── [isAdmin] OrgAdminSections                ← four new entries in sectionList
+    ├── MembersSection                        ← `.ui-container`
+    │   ├── MemberRow × N                     ← `.ui-item`
+    │   │   ├── AvatarInitial                 ← fixed square media slot
+    │   │   ├── NameAndEmail                  ← `.ui-item-label`, two lines
+    │   │   ├── RoleDropdown                  ← shared dropdown primitive (admin/clerk/user/worker/viewer)
+    │   │   └── RowMenu (⋯)                   ← "Remove from organization"
+    │   └── [loading] SkeletonRows
+    ├── SharingSection                        ← `.ui-container`
+    │   ├── ShareSetRow × N                   ← token_prefix (mono) + creator/count/expiry meta + Revoke
+    │   ├── ShowInactiveToggle                ← reveals revoked/expired group
+    │   └── [empty] EmptyState                ← "No active share links"
+    ├── ActivitySection                       ← `.ui-container`
+    │   ├── ActionTypeFilter                  ← shared dropdown, "All actions" default
+    │   ├── AuditRow × N                      ← icon + sentence + relative time
+    │   └── LoadMoreButton                    ← ghost, paginated
+    └── OrganizationSection                   ← `.ui-container`
+        ├── OrgNameField                      ← inline edit + Save
+        └── OrgMetaRows                       ← org id (copyable), member count (read-only)
+```
+
+### Wiring Flow (Mermaid)
+
+```mermaid
+flowchart LR
+  Overlay[SettingsOverlayComponent] -->|isAdmin gate| Sections[OrgAdmin sections]
+  Sections --> Admin[OrgAdminService]
+  Sections --> Roles[OrgRoleService]
+  Admin --> RPC[Supabase RPCs / tables]
+  Admin --> Edge[remove-member edge function]
+  RPC --> Audit[(audit_events)]
+```
+
+### Data Flow (Mermaid)
+
+```mermaid
+sequenceDiagram
+  participant C as MembersSection
+  participant S as OrgAdminService
+  participant DB as Supabase
+
+  C->>S: loadMembers()
+  S->>DB: rpc('list_org_members')
+  DB-->>S: members + roles
+  S-->>C: OrgMember[]
+  C->>S: setRole(userId, 'clerk')
+  S->>DB: rpc('set_user_role', {…})
+  DB->>DB: guard last admin, write audit_events
+  DB-->>S: ok | error
+  S-->>C: confirm or revert optimistic row
+```
+
+## Data
+
+| Field            | Source                                                                       | Type              |
+| ---------------- | ---------------------------------------------------------------------------- | ----------------- |
+| Members          | `supabase.rpc('list_org_members')` (new, admin-only, security definer)       | `OrgMember[]`     |
+| Role change      | `supabase.rpc('set_user_role', { target_user_id, role_name })` (new)         | `void`            |
+| Member removal   | `remove-member` edge function (new, service role)                            | `void`            |
+| Share sets       | `supabase.from('share_sets').select('id, token_prefix, created_by, expires_at, revoked_at, created_at, share_set_items(count)')` | `ShareSetRow[]`   |
+| Share-set revoke | `supabase.from('share_sets').update({ revoked_at })` (existing RLS: creator or admin) | `void`     |
+| Audit events     | `supabase.from('audit_events').select(…)` (new table, admin org read)        | `AuditEvent[]`    |
+| Org profile      | `supabase.from('organizations').select('id, name')` / `.update({ name })` (new admin-update RLS policy) | `Organization` |
+
+Required new DB objects (see audit doc P1/P2/P4/P5): `list_org_members()`, `set_user_role()`, `audit_events`, `organizations` admin-update policy, `share_sets` admin-read-all policy, `remove-member` edge function.
+
+## State
+
+| Name              | Type                          | Default  | Controls                               |
+| ----------------- | ----------------------------- | -------- | --------------------------------------- |
+| `members`         | `OrgMember[]`                 | `[]`     | Members list                            |
+| `pendingRoleEdit` | `string \| null`              | `null`   | Row showing optimistic role change      |
+| `shareSets`       | `ShareSetRow[]`               | `[]`     | Sharing list                            |
+| `showInactive`    | `boolean`                     | `false`  | Include revoked/expired share sets      |
+| `auditEvents`     | `AuditEvent[]`                | `[]`     | Activity list (paged)                   |
+| `actionFilter`    | `string \| null`              | `null`   | Activity action-type filter             |
+| `orgName`         | `string`                      | `''`     | Org rename field                        |
+| `loading`         | `Record<SectionId, boolean>`  | all false| Per-section skeletons                   |
+
+`OrgRoleService` (new, `core/org-role.service.ts`) provides `roles`, `isAdmin`, `isViewer` signals loaded once per session.
+
+## Settings
+
+- **Members & Roles**: member list visibility, role assignment, and member removal controls (admin-only).
+- **Sharing Administration**: org-wide share-link listing and revocation, including inactive-link visibility (admin-only).
+- **Activity Log**: audit event visibility, pagination size, and action-type filters (admin-only).
+- **Organization Profile**: organization rename and identity metadata display (admin-only).
+
+## File Map
+
+| File                                                                          | Purpose                                  |
+| ----------------------------------------------------------------------------- | ---------------------------------------- |
+| `core/org-role.service.ts`                                                    | Session role signals (`isAdmin` etc.)    |
+| `core/org-admin.service.ts`                                                   | Members/sharing/audit/org data access    |
+| `features/settings-overlay/sections/members-section.component.ts/.html/.scss` | Members sub-section                      |
+| `features/settings-overlay/sections/sharing-admin-section.component.ts/.html/.scss` | Sharing sub-section                |
+| `features/settings-overlay/sections/activity-section.component.ts/.html/.scss`| Activity sub-section                     |
+| `features/settings-overlay/sections/organization-section.component.ts/.html/.scss` | Organization sub-section            |
+| `supabase/migrations/<ts>_org_admin_rpcs.sql`                                 | `list_org_members`, `set_user_role`, `audit_events`, new policies |
+| `supabase/functions/remove-member/index.ts`                                   | Service-role member removal              |
+
+## Wiring
+
+### Injected Services
+
+- `OrgRoleService` — admin gating signal for section visibility.
+- `OrgAdminService` — all Supabase calls for these sections.
+- `I18nService` — section titles, row text, confirmations (en/de/it per i18n workflow).
+- `ToastService` (existing toast system) — success/error feedback.
+
+### Inputs / Outputs
+
+None — sections are mounted by `SettingsOverlayComponent` like existing sections.
+
+### Subscriptions
+
+- `OrgRoleService.isAdmin` signal read in `sectionList` computed (no manual teardown).
+- Section data loads are promise-based on section open; no long-lived subscriptions.
+
+### Supabase Calls
+
+None in components — delegated to `OrgAdminService` (tables/RPCs listed in Data).
+
+- Extend `sectionList` in `settings-overlay.component.ts` with the four entries carrying `adminOnly: true`, filtered through `OrgRoleService.isAdmin()`.
+- Register all new user-facing strings in `docs/i18n/translation-workbench.csv` and regenerate `supabase/seed_i18n.sql`.
+
+## Acceptance Criteria
+
+- [ ] Sections are absent from the settings overlay for non-admin users (and Search Tuning gains the same `adminOnly` gate)
+- [ ] Members list shows every org member with name, email, and current roles
+- [ ] Changing a role persists via `set_user_role()` and reverts visually on error
+- [ ] Demoting or removing the last admin fails with a clear inline message (enforced by the DB, surfaced by the UI)
+- [ ] Removing a member requires a confirm dialog and deletes the user per the lifecycle cascade
+- [ ] Sharing section lists all active share sets org-wide with creator, item count, and expiry
+- [ ] Revoking a share set stops `?share=` resolution immediately and moves the row to the inactive group
+- [ ] Activity section shows audit rows for role changes, removals, invite/share lifecycle, and org rename
+- [ ] Org rename persists and is reflected after reload
+- [ ] All RLS/RPC guards hold when called directly against the API with a non-admin JWT (frontend gating is UX only)

--- a/docs/element-specs/search-bar.md
+++ b/docs/element-specs/search-bar.md
@@ -14,6 +14,7 @@ This parent spec defines the implementation contract for the search surface UI a
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [search-bar-query-behavior](search-bar-query-behavior.md)     | Address label formatting, ghost completion, forgiving matching, search/filter integration rules   |
 | [search-bar-data-and-service](search-bar-data-and-service.md) | Data pipeline phases, geocoder biasing, ranking formulas, service responsibilities and interfaces |
+| [filter-toolbar](filter-toolbar.md)                           | Docked filter chip row below the search bar; `#`/`+`/`-` keyword operators and provider scoping are planned in the [Universal Search Provider System blueprint](../implementation-blueprints/universal-search-provider-system.md) |
 
 ## What It Looks Like
 

--- a/docs/implementation-blueprints/universal-search-provider-system.md
+++ b/docs/implementation-blueprints/universal-search-provider-system.md
@@ -1,0 +1,189 @@
+# Universal Search Provider System — Implementation Blueprint
+
+> **Specs**: [element-specs/search-bar.md](../element-specs/search-bar.md) (host surface),
+> [element-specs/filter-toolbar.md](../element-specs/filter-toolbar.md) (chip toolbar),
+> [element-specs/search-bar-query-behavior.md](../element-specs/search-bar-query-behavior.md) (base query rules)
+> **Status**: Planned. Extends the implemented search stack (orchestrator + 3 resolvers + `/` command mode) with a formal provider interface, `#`/`+`/`-` keyword operators, and a reusable filter toolbar.
+
+## Goals
+
+1. **Providers, not hardcoded resolvers.** Formalize the existing three sources
+   (DB address, DB content, geocoder) plus commands and filters behind one
+   `SearchProvider` interface so new sources register instead of being wired into
+   the orchestrator by hand.
+2. **Keyword operators.** `#` scopes the search exclusively to one provider;
+   `+`/`-` add/remove filter chips — exactly equivalent to toggling a chip in the
+   filter toolbar.
+3. **Reusable filter toolbar.** A floating chip row that docks under *any* search
+   bar host (map first; workspace pane / image detail and photos page later) and
+   stays in sync with `FilterService` and the operator grammar.
+
+## Existing Infrastructure (verified)
+
+| File | What it provides |
+| --- | --- |
+| `core/search/search-orchestrator.service.ts` | Debounce (300ms), 5-min cache, staged emission (`typing → results-partial → results-complete`), ranking, dedup; `configureSources()` accepts exactly 3 resolver slots; `/` command mode with 3 hardcoded commands |
+| `core/search/search-bar-resolvers.ts` | DB address / DB content / geocoder resolution + scoring |
+| `core/search/search.models.ts` | `SearchCandidate` union, `SearchSection`, `SearchQueryContext` (already carries `activeProjectId`, `activeFilterCount`, `commandMode`) |
+| `core/filter.service.ts` | `FilterRule { conjunction, property, operator, value }` signal store, client-side evaluation, `activeCount` computed |
+| `features/map/search-bar/search-bar.component.ts` | Input handling, keyboard nav, ghost completion, commit routing |
+| `docs/element-specs/active-filter-chips.md` | Earlier chip-row spec — **superseded by the Filter Toolbar** (see below) |
+
+## 1. Provider Interface
+
+```typescript
+// core/search/providers/search-provider.ts
+export interface SearchProvider {
+  /** Stable id, used by #-scoping and section keys. */
+  readonly id: 'project' | 'address' | 'place' | 'group' | 'command' | string;
+  /** i18n keys: noun shown in meta rows + section header. */
+  readonly labelKey: string;        // e.g. 'search.provider.project' → "Projekt"
+  readonly descriptionKey: string;  // e.g. "Suche nach einem konkreten Projekt"
+  /** Aliases matched after '#', lowercase, per locale (e.g. ['projekt','project','proj']). */
+  readonly aliases: string[];
+  /** Which operators this provider participates in. */
+  readonly capabilities: { scope: boolean; filter: boolean };
+  resolve(query: string, context: SearchQueryContext): Observable<SearchCandidate[]>;
+  /** Map a committed candidate to a FilterRule (only if capabilities.filter). */
+  toFilterRule?(candidate: SearchCandidate): FilterRule;
+}
+```
+
+Registration replaces the 3-slot `configureSources()`:
+
+```typescript
+// core/search/providers/search-provider.registry.ts
+@Injectable({ providedIn: 'root' })
+export class SearchProviderRegistry {
+  register(provider: SearchProvider): void;
+  byId(id: string): SearchProvider | undefined;
+  matchAlias(prefix: string): SearchProvider[]; // for '#proj…' narrowing
+  all(): SearchProvider[];
+}
+```
+
+Migration is mechanical: wrap the three existing resolver functions in provider
+objects (`AddressProvider`, `PlaceProvider`, and split DB content into
+`ProjectProvider` + `GroupProvider` so `#project` can be exclusive). The
+orchestrator iterates registered providers instead of its three fields; staged
+emission, caching, dedup, and ranking are unchanged. `/` command mode becomes a
+`CommandProvider` with `capabilities: { scope: true, filter: false }`.
+
+## 2. Operator Grammar
+
+Parsing happens in a new pure module `core/search/search-operators.ts`, invoked in
+`onInput()` **before** debounce/orchestration (like coordinate detection today).
+
+```
+input        := operator-token | plain-query
+operator-token := ('#' | '+' | '-') rest
+rest         := '' | provider-alias [' ' term] | term
+```
+
+| Input | Meaning | Behavior |
+| --- | --- | --- |
+| `#` (bare) | "scope my search" | Dropdown shows **meta rows**: one two-line row per scopable provider (line 1 noun e.g. "Projekt", line 2 description e.g. "Suche nach einem konkreten Projekt"), contextually ranked (active project context boosts Projekt; map viewport boosts Adresse/Ort) |
+| `#proj` | narrowing | Meta rows filtered by alias prefix; Enter/click selects the provider |
+| `#projekt term` (or provider selected) | exclusive scope | Orchestrator queries **only** that provider; section header shows the provider noun; all other sections suppressed |
+| `+` (bare) | "add a filter" | Meta rows for filterable providers/dimensions: Projekt, Zeitraum, Metadatum (set TBD — start with Projekt, extend per `FilterService` properties) |
+| `+term` | add filter chip | Resolves `term` against filterable providers (projects first); committing a candidate calls `toFilterRule()` → `FilterService.add()`, chip appears in the toolbar, input clears. Identical to toggling the chip on |
+| `-` (bare) | "remove a filter" | Meta rows list the **currently active chips**; selecting one removes it |
+| `-term` | remove filter chip | Fuzzy-matches `term` against active chips; commit removes the matching rule. Identical to clicking a chip's × |
+| `/…` | commands | Unchanged, internally now `#`-scoping the `CommandProvider` |
+
+Rules:
+
+- Operator detection only at position 0 of the trimmed input; `Bahnhofstr. 5 #3`
+  is a plain query (no mid-string operators in v1).
+- Escape/backspace from an active scope returns to plain search with the operator
+  text still editable (the scope is part of the input string, not hidden state).
+- Selecting an entity that is **already an active chip** via `+`/`#` toggles it
+  **off** (re-selecting toggles — same as clicking the chip).
+- Coordinate detection keeps priority over operator detection only when the input
+  parses as coordinates (unchanged behavior); `#`/`+`/`-` never collide with it.
+
+### Meta-suggestion rows
+
+New candidate family `meta` in `search.models.ts`:
+
+```typescript
+export interface SearchMetaCandidate {
+  family: 'meta';
+  providerId: string;
+  operator: '#' | '+' | '-';
+  label: string;        // resolved i18n noun, e.g. "Projekt"
+  description: string;  // resolved i18n line 2
+}
+```
+
+Rendered by `search-dropdown-item.component.ts` as a two-line row (noun on line 1
+in primary text, description on line 2 in `--color-text-secondary`), icon by
+provider (folder for Projekt, location for Adresse, globe for Ort, history/chip
+icon for active-chip rows under `-`). Committing a meta row **rewrites the input**
+(`#` + alias + space, focus kept) rather than performing a search — one mental
+model: operators always travel through the input text.
+
+### i18n
+
+All operator nouns/descriptions go through the mandatory i18n workflow
+(`docs/i18n/translation-workbench.csv` → `supabase/seed_i18n.sql`), en/de/it.
+Initial keys: `search.operator.scopeHint`, `search.provider.{project,address,place,group,command}.label`,
+`search.provider.*.description`, `search.operator.addFilterHint`, `search.operator.removeFilterHint`.
+German reference copy: "Projekt" / "Suche nach einem konkreten Projekt".
+
+## 3. Filter Toolbar Sync Contract
+
+Full UI contract in [element-specs/filter-toolbar.md](../element-specs/filter-toolbar.md).
+Architecture decision (resolves the "map-only vs reusable" question): **reusable
+component, single source of truth in `FilterService`**, map ships first.
+
+```mermaid
+flowchart LR
+  Input[Search input] -->|"+/- commit"| Ops[search-operators.ts]
+  Ops --> FS[FilterService rules signal]
+  Toolbar[FilterToolbarComponent] <-->|read rules / toggle & remove| FS
+  FS -->|activeFilterCount + rules| Ctx[SearchQueryContext]
+  Ctx --> Orch[SearchOrchestratorService]
+  FS --> Hosts[Host surfaces: map markers, workspace grid, detail view]
+```
+
+- The toolbar never owns filter state; it renders `FilterService.rules()` and
+  calls `add/remove/toggle`. Operator commits go through the same service
+  methods — chips created by typing `+x` and by clicking are indistinguishable.
+- `SearchQueryContext` gains `activeFilterRules` (today only `activeFilterCount`)
+  so providers can boost/suppress candidates that are already filtered.
+- Host surfaces subscribe to `FilterService` exactly as the map does today;
+  docking the toolbar under another search bar requires no new wiring beyond
+  placing the component (see spec for the docking contract).
+
+### Where the toolbar appears
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| Map (below Search Bar, top-center) | **v1** | Replaces the planned Active Filter Chips strip |
+| Workspace pane / image detail view | **v2** | No search bar exists there yet; when one lands, the toolbar docks beneath it with the same `FilterService`. Until then the workspace inherits map filters (already the case via shared service) |
+| Photos page | **deferred** | Page is a stub; adopt the same docking contract when it gets a search bar |
+
+`active-filter-chips.md` is superseded by the Filter Toolbar spec — do not
+implement both. The chips spec's acceptance criteria are absorbed.
+
+## 4. Implementation Phases
+
+| Phase | Scope | Files |
+| --- | --- | --- |
+| 1 | Provider interface + registry; wrap existing resolvers; split project/group providers; orchestrator iterates registry (behavior-neutral refactor, all existing specs stay green) | `core/search/providers/*`, `search-orchestrator.service.ts` |
+| 2 | Operator parser + `meta` candidate family + meta rows + `#` exclusive scoping | `core/search/search-operators.ts`, `search.models.ts`, `search-bar.component.ts`, `search-dropdown-item.component.ts` |
+| 3 | Filter Toolbar component (map) + `+`/`-` bridge to `FilterService` + toggle-off semantics | `shared/filter-toolbar/*`, `core/filter.service.ts` |
+| 4 | Context enrichment (`activeFilterRules`), provider boosts, second surface adoption | `search.models.ts`, host components |
+
+Each phase is independently shippable; phase 2 without phase 3 degrades
+gracefully (`+`/`-` hidden from meta suggestions until the toolbar exists).
+
+## Testing Notes
+
+- `search-operators.spec.ts`: pure parser table tests (bare ops, alias narrowing,
+  toggle-off, position-0 rule, coordinate precedence).
+- Extend `search-orchestrator.service.spec.ts`: registry iteration preserves
+  staged emission and ranking parity with the pre-refactor snapshot.
+- Toolbar specs per element spec acceptance criteria; chip↔operator equivalence
+  asserted by driving both paths and diffing `FilterService.rules()`.

--- a/docs/org-administration-audit.md
+++ b/docs/org-administration-audit.md
@@ -1,0 +1,171 @@
+# Organization Administration — Audit & Gap-Closing Plan
+
+**Who this is for:** engineers and product owners planning org-level admin, member/role
+management, and sharing controls.
+**What you'll get:** a verified current-state inventory (DB + RLS + UI), an evaluation
+against standard SaaS administration areas, and a prioritized implementation plan.
+
+See also: `role-permissions.md`, `user-lifecycle.md`, `security-boundaries.md`,
+`element-specs/org-administration-section.md` (the new UI contract derived from this audit).
+
+Status: audit complete (2026-06-12). Implementation not started.
+
+---
+
+## 1. Scope & Corrections to Prior Assumptions
+
+This audit verified the repository state directly. Three assumptions from earlier
+planning notes turned out to be wrong and are corrected here:
+
+1. **There is no `settings-section-registry.ts` and no `isOrgAdmin` UI gating.**
+   The settings overlay section list is a hardcoded `computed` in
+   `features/settings-overlay/settings-overlay.component.ts` (lines 69–127).
+   No settings section is role-gated in the UI today — including Search Tuning.
+   All gating happens at the database (RLS) level only.
+2. **`features/groups/` is NOT a placeholder for org teams.** It is the placeholder
+   for personal *image* groups (`saved_groups`, per-user collections — see
+   `element-specs/groups-page.md`, planned for M-UI7). Org/team management has no
+   reserved feature folder yet; this plan introduces it under the settings overlay
+   instead (see §5), because every other org-scoped control already lives there.
+3. **There are no anonymous share links.** `resolve_share_set()` requires an
+   authenticated session in the same organization (`public.user_org_id()` check in
+   `supabase/migrations/20260318090000_share_sets.sql`). Share-set tokens are
+   org-internal deep links, not public links.
+
+## 2. Verified Current State
+
+### 2.1 Database
+
+| Table | Purpose | Admin-relevant RLS |
+| --- | --- | --- |
+| `organizations` | Org identity — `name` only, no branding/settings/updated_at | Read own org only; **no update policy at all** |
+| `profiles` | 1:1 with `auth.users`, carries `organization_id` | **Self-read only** (or admin); self-update |
+| `roles` | 5 seeded roles: `admin`, `clerk`, `user`, `worker`, `viewer` | Read: authenticated |
+| `user_roles` | M:N user↔role | Read: self or admin; **insert/delete: admin only** (UI missing) |
+| `projects` | Org-scoped | Update org-wide for non-viewers (relaxed); delete owner-or-admin |
+| `qr_invites` | Invite links/QR, `target_role ∈ {clerk, worker}`, status lifecycle, hashed token, 7-day expiry | Create: admin/clerk/worker via `can_create_qr_invites()`; update: creator or admin |
+| `invite_share_events` | Append-only log of invite share channel (copy-link/email/whatsapp/qr-scan) | Org read; actor insert |
+| `share_sets` + `share_set_items` | Stable shareable image selections (workspace export), hashed token, `revoked_at` soft revoke, fingerprint reuse | Org read (active only); revoke/delete: creator or admin |
+| `coordinate_corrections` | Append-only audit of marker moves | Org read; non-viewer insert; no update/delete |
+| `saved_groups` | Personal image groups — **not** teams | Owner-only everything |
+
+Helper functions: `user_org_id()`, `is_admin()`, `is_viewer()`
+(`supabase/migrations/20260303000004_functions_and_triggers.sql:5–45`).
+
+RPCs: `create_or_reuse_share_set()`, `resolve_share_set()`
+(`20260318090000_share_sets.sql:114–252`).
+
+### 2.2 Frontend
+
+| Area | State |
+| --- | --- |
+| Role exposure | `UserProfileService.getOwnProfile()` returns `roles: string[]`; no cached signal, **no `isAdmin` computed anywhere** |
+| Settings overlay | 8 hardcoded sections (general, appearance, notifications, map, search, data, account, invite-management); none role-gated |
+| Invite management UI | Create draft (worker/clerk), QR render, copy/email/WhatsApp share, regenerate, revoke — but only the invite created in the current session; **no invite history list** |
+| Share-set UI | Create/copy link in `workspace-export-bar.component.ts`; resolve via `?share=` param; **no list/revoke UI anywhere** |
+| Member management UI | **None.** Role assignment happens via SQL migrations (e.g. `20260318152000_promote_kleveta_admin.sql` hardcodes an email) |
+| Org settings UI | **None** (account page edits the personal profile only) |
+| Audit log UI | **None** (and no general audit table to read from) |
+
+## 3. Evaluation Against Standard SaaS Areas
+
+| # | Standard area | Status | Gap summary |
+| --- | --- | --- | --- |
+| A | Org settings (name, branding, defaults) | 🔴 Missing | DB has only `name` with no update policy; no UI |
+| B | Member/team management (list, change role, remove) | 🔴 Missing | RLS for role writes exists (admin), but profiles are self-read-only so an admin cannot even *list* members; no removal path (needs service-role/edge function for `auth.users` delete) |
+| C | Role-based UI surface | 🔴 Missing | No frontend role signal; viewers see write affordances that RLS then rejects; admin-only sections impossible today |
+| D | Sharing controls (view/revoke active share sets) | 🟡 Partial | DB fully supports list + soft revoke (creator/admin RLS); zero UI |
+| E | Invites | 🟡 Partial | Solid create/share/revoke flow + share-event logging, but session-local only: no history, no admin oversight of others' invites, no `user`/`viewer`/`admin` target roles |
+| F | Audit/activity log | 🔴 Missing | Only `coordinate_corrections` and `invite_share_events` exist; no membership/role/sharing/org-settings audit, no UI |
+| G | Project-level vs org-wide access | 🟡 Partial | All access is org-wide; no per-project membership. Relaxed policies (org-wide update/delete on images/projects for any non-viewer) are documented in `role-permissions.md` as a pre-launch decision |
+
+## 4. Prioritized Gap-Closing Plan
+
+Ordering rationale: C unblocks everything (no admin UI can ship without a frontend
+role signal); B is the most painful operational gap (role changes require migrations
+today); D is high-value/low-cost (DB already done); A, E-extensions, F, G follow.
+
+### P0 — Role signal + admin gating foundation (prereq, small)
+
+- Add `OrgRoleService` (`core/org-role.service.ts`): loads own roles once per session,
+  exposes `roles: Signal<string[]>`, `isAdmin: Signal<boolean>`, `isViewer: Signal<boolean>`.
+- Extend the settings overlay section model with `adminOnly?: boolean` and filter
+  `sectionList` through `OrgRoleService.isAdmin()`. This is UX-gating only; RLS remains
+  the security boundary (frontend stays untrusted).
+- Optionally hide write affordances from viewers using the same signal (separate, incremental).
+
+### P1 — Member management (closes B, the operational blocker)
+
+- **Migration:** `list_org_members()` security-definer RPC returning
+  `{ user_id, full_name, email, roles[], created_at }` for the caller's org, admin-only
+  (preferred over widening `profiles` RLS, which would leak member emails to all members).
+- **Migration:** `set_user_role(user_id, role_name)` RPC — admin-only, same-org check,
+  refuses to remove the last admin, writes an audit row (see P4 — ship the `audit_events`
+  table with this migration so role changes are logged from day one).
+- **Edge function:** `remove-member` — service-role deletion from `auth.users`
+  (cascades per `user-lifecycle.md` §5); admin-only, refuses self-removal and last-admin removal.
+- **UI:** "Members" settings section (admin-only) — list, role dropdown, remove with
+  confirm dialog. Contract: `element-specs/org-administration-section.md`.
+
+### P2 — Sharing controls (closes D; DB already complete)
+
+- **UI only:** "Sharing" settings section (admin-only) listing active share sets
+  (`token_prefix`, creator, item count, created/expires) with per-row revoke
+  (`update share_sets set revoked_at = now()` — existing RLS already permits creator/admin).
+- Include revoked/expired rows behind a toggle. Requires a small RLS addition:
+  current `org read active` policy hides revoked rows, so add an admin-read-all policy.
+
+### P3 — Invite completeness (closes E)
+
+- **UI:** invite history list inside the existing Invite Management section: all org
+  invites (org-read RLS already allows this) with status, target role, creator,
+  expiry, and revoke action for active ones.
+- **Decision needed:** whether `user` and `viewer` become valid `target_role` values
+  (one-line check-constraint migration). `admin` should stay excluded from invites
+  (admin promotion only via Members UI, which is audited).
+- Surface `invite_share_events` per invite (channel + time) in an expandable row.
+
+### P4 — Audit log (closes F)
+
+- **Migration:** `audit_events` table — `id, organization_id, actor_user_id, action,
+  target_type, target_id, detail jsonb, created_at`; append-only (no update/delete
+  policies), org-scoped admin read. Writes happen inside the P1/P2/P3 RPCs and
+  triggers, never from the client.
+- Seed actions: `role.assigned`, `role.revoked`, `member.removed`, `invite.created`,
+  `invite.revoked`, `share_set.created`, `share_set.revoked`, `org.renamed`.
+- **UI:** "Activity" settings section (admin-only), reverse-chronological, filter by action type.
+
+### P5 — Org settings (closes A)
+
+- **Migration:** add `organizations: admin update` RLS policy (+ `updated_at` column);
+  defer branding/logo until a concrete need exists (storage bucket + render surface).
+- **UI:** "Organization" settings section (admin-only): rename org; show org id and
+  member count. Future home for defaults (e.g. default invite expiry, default map layer org-wide).
+
+### P6 — Project-level access (G — decision, not a quick fix)
+
+- Resolve the `role-permissions.md` "Production Decision Required" first (tighten
+  org-wide non-viewer writes to owner-or-admin, or accept current behavior).
+- Per-project membership (a `project_members` table consulted by RLS) is a structural
+  change touching every image/project policy. Recommendation: defer until a customer
+  needs sub-org isolation; the role split (clerk/worker explicit policies) should land first.
+
+## 5. Where the UI Lives
+
+All new surfaces are **settings overlay sections** (not a separate admin dashboard
+route): the overlay is already the home of org-scoped controls (invite management,
+custom properties), it is reachable from everywhere, and sections are cheap to gate
+once P0 lands. If the admin surface outgrows the overlay (audit log pagination,
+member search), promote the sections to a routed `/admin` page later — the section
+components are written to be host-agnostic so this is a re-mounting exercise.
+
+`features/groups/` stays reserved for image groups (M-UI7) and is not used by this plan.
+
+## 6. Acceptance Snapshot (when is this "done")
+
+- [ ] An admin can see who is in the org, change any member's role, and remove a member — without SQL.
+- [ ] A non-admin never sees admin sections; a viewer never sees write affordances that RLS would reject.
+- [ ] An admin can list and revoke every active share link and every active invite in the org.
+- [ ] Every role change, member removal, invite/share-set lifecycle event, and org rename is in `audit_events` and visible in the Activity section.
+- [ ] The org can be renamed from the UI.
+- [ ] The last admin cannot be demoted or removed (enforced in DB, not just UI).

--- a/docs/settings-registry.md
+++ b/docs/settings-registry.md
@@ -8,12 +8,14 @@ Do not edit manually; update element specs and run `node scripts/lint-specs.mjs 
 | 2FA | account-page.md | enrollment defaults, factor visibility, and removal safeguards. |
 | 2FA | account-settings-section.md | allowed factor types, enrollment flow defaults, assurance indicator display, and removal constraints. |
 | Account & Session | settings-overlay.md | profile identity, email/password security, password recovery, 2FA setup/management, and session termination controls. |
+| Activity Log | org-administration-section.md | audit event visibility, pagination size, and action-type filters (admin-only). |
 | Custom Properties | settings-overlay.md | organization metadata key configuration defaults. |
 | Data & Storage | settings-overlay.md | data retention/export/cache/storage defaults. |
 | Email Change Security | account-page.md | verification requirements and pending-state copy. |
 | Email Change Security | account-settings-section.md | whether dual-email confirmation is required and how pending verification is shown. |
 | Export & Sharing | workspace-export-bar.md | default share-link expiration, allow token reuse vs forced regeneration, and whether native-share action is enabled on supported devices. |
 | File Type Visibility | project-mixed-media-pre-spec.md | default selected media families in map/workspace/project views. |
+| Filter Toolbar | filter-toolbar.md | chip overflow behavior (wrap vs horizontal scroll on mobile) and the chip-count threshold at which "Clear all" appears. |
 | Fullscreen Project Mode | project-mixed-media-pre-spec.md | default entry behavior for project detail (inline pane vs fullscreen). |
 | Identity Profile | account-page.md | display name edit behavior and validation. |
 | Identity Profile | account-settings-section.md | display name edit policy, formatting, and save behavior. |
@@ -26,7 +28,9 @@ Do not edit manually; update element specs and run `node scripts/lint-specs.mjs 
 | Map Basemap | map-zone.md | sets the default map layer (`default` or `satellite`) and whether the last user choice is persisted across sessions. |
 | Map Marker Motion | photo-marker.md | toggles marker fade-in and centroid glide transitions during cluster reconciliation (`Off` or `Smooth`). |
 | Map Preferences | settings-overlay.md | map tile and map-behavior defaults. |
+| Members & Roles | org-administration-section.md | member list visibility, role assignment, and member removal controls (admin-only). |
 | Notifications | settings-overlay.md | preference defaults for in-app feedback and alerts. |
+| Organization Profile | org-administration-section.md | organization rename and identity metadata display (admin-only). |
 | Password Recovery | account-page.md | reset email behavior and redirect target. |
 | Password Recovery | account-settings-section.md | reset email trigger behavior and redirect target handling. |
 | Password Security | account-page.md | policy messaging and re-auth requirement handling. |
@@ -43,5 +47,6 @@ Do not edit manually; update element specs and run `node scripts/lint-specs.mjs 
 | Selection Bulk Actions | workspace-export-bar.md | default delete confirmation behavior, whether address-change requires non-empty validation, and which project targets are shown first (recent vs alphabetical). |
 | Session | account-page.md | logout confirmation and scope behavior. |
 | Session | account-settings-section.md | explicit sign-out behavior and confirmation requirements. |
+| Sharing Administration | org-administration-section.md | org-wide share-link listing and revocation, including inactive-link visibility (admin-only). |
 | Theme | settings-overlay.md | active theme mode and persistence behavior. |
 | Workspace Sort Defaults | settings-overlay.md | default sorting and ordering preferences. |


### PR DESCRIPTION
## Summary

This PR adds three major documentation blueprints and specifications that establish the foundation for organization administration, a formalized search provider architecture, and a reusable filter toolbar component. These are planning and specification documents that define the contracts and implementation strategy for upcoming features.

## Key Changes

### 1. Organization Administration Audit & Sections Spec
- **`docs/org-administration-audit.md`**: Comprehensive audit of current org-level capabilities (members, roles, sharing, audit logs) against standard SaaS admin areas. Identifies 7 major gaps (member management, role assignment, sharing controls, audit logging, org settings) and provides a prioritized 6-phase implementation plan (P0–P6).
- **`docs/element-specs/org-administration-section.md`**: UI contract for four new admin-only settings overlay sections:
  - Members: list, role assignment, removal with confirm dialog
  - Sharing: active share-set listing and revocation
  - Activity: audit event log with action-type filtering
  - Organization: org rename and metadata display
  - Includes component hierarchy, data flows, state management, and acceptance criteria

### 2. Universal Search Provider System Blueprint
- **`docs/implementation-blueprints/universal-search-provider-system.md`**: Formal specification for refactoring the existing search orchestrator from hardcoded resolvers to a pluggable provider interface. Defines:
  - `SearchProvider` interface with registration via `SearchProviderRegistry`
  - Operator grammar (`#` for scoping, `+`/`-` for filter operations) with meta-suggestion rows
  - Integration with `FilterService` for filter toolbar sync
  - Four-phase implementation plan with independent shippability
  - Testing strategy and migration path from existing resolver architecture

### 3. Filter Toolbar Spec
- **`docs/element-specs/filter-toolbar.md`**: Reusable component specification for a docked filter-chip row that:
  - Displays active filters as toggleable, removable pills
  - Syncs bidirectionally with `FilterService` and search operator commits
  - Docks under any search bar (map first, workspace/detail/photos later)
  - Supports keyboard navigation, animations, and mobile overflow handling
  - Includes wiring flow, data flow, and acceptance criteria

### 4. Documentation Updates
- **`docs/element-specs/README.md`**: Updated to mark `active-filter-chips.md` as superseded by `filter-toolbar.md`
- **`docs/element-specs/active-filter-chips.md`**: Added deprecation notice pointing to `filter-toolbar.md`
- **`docs/element-specs/search-bar.md`**: Added reference to the new search provider system blueprint
- **`docs/settings-registry.md`**: Updated to reflect new admin-only settings sections

## Notable Implementation Details

- **Org Admin P0 blocker**: `OrgRoleService` (role signal) must land first to enable UI-level admin gating; all subsequent phases depend on it
- **Search provider migration**: Existing three resolvers (address, content, geocoder) wrap into provider objects; orchestrator iterates registry instead of fixed slots; behavior-neutral refactor with all existing specs staying green
- **Filter toolbar reusability**: Component takes no host-specific inputs; docking on new surfaces requires only placement in HTML; state is global via `FilterService`
- **Operator grammar**: Parsing happens pre-debounce in search bar input handler; coordinate detection retains priority; meta-suggestion rows rewrite input rather than performing searches
- **Audit foundation**: `audit_events` table ships with P1 (member management) so role changes are logged from day one

## Acceptance & Next Steps

These are specification and planning documents. Implementation follows the prioritized phases outlined in each blueprint:
- Org Admin: P0 (role signal) unblocks all others
- Search Provider: Phase 1 (provider interface) enables phases 2–4
- Filter Toolbar: Phase 3 of search provider system; phase 2 degrades gracefully without it

All new user-facing strings are registered through the mandatory i18n workflow (en/de/it).

https://claude.ai/code/session_01ViTngGqWaqmfgV9wgnEvBZ